### PR TITLE
feat: étendre le resolver diplomatique au roster complet

### DIFF
--- a/docs/diplomacy-extraction.md
+++ b/docs/diplomacy-extraction.md
@@ -1,0 +1,43 @@
+# Extraction des relations diplomatiques WH3
+
+Le projet ne doit jamais convertir une donnée absente en score `0` ou en relation neutre.
+
+## Export RPFM requis
+
+Exporter au format TSV les tables suivantes en conservant la structure `db/<table>/data__.tsv` :
+
+- `campaign_group_members_tables`
+- `campaign_group_member_criteria_factions_tables`
+- `campaign_group_member_criteria_diplomatic_attitudes_tables`
+- les tables startpos utilisées par `tools/import_start_pos.py`
+
+Les critères culture/sous-culture, faction sets et scripts de campagne sont des sources complémentaires : tant qu'ils ne sont pas résolus, le rapport reste `partial`.
+
+## Résolution des catégories directes
+
+Depuis PowerShell, à la racine du dépôt :
+
+```powershell
+python tools/resolve_diplomatic_categories.py `
+  --db-dir data/raw/db `
+  --game-version "<version WH3>" `
+  --output data/generated/diplomatic-categories.json
+```
+
+Pour limiter temporairement l'analyse à un ensemble de factions, fournir un fichier texte contenant une clé de faction par ligne avec `--factions`.
+
+La sortie conserve la table source, le membre de groupe, le contexte et la catégorie d'attitude. Elle n'invente pas de valeur numérique.
+
+## Étapes de reconstruction du tour 1
+
+1. Extraire guerres et traités explicites du startpos.
+2. Résoudre les critères directs de faction.
+3. Étendre les critères de faction sets, culture et sous-culture.
+4. Appliquer les effets de faction qui modifient les relations diplomatiques.
+5. Inspecter les scripts de campagne pour les changements/forçages de diplomatie.
+6. Conserver la direction `sourceFaction -> targetFaction` à chaque étape.
+7. Produire le score seulement lorsque toutes les composantes nécessaires sont démontrées.
+
+## Validation
+
+Les premières validations en jeu restent Imrik, Karl Franz, Malus Darkblade et Ku'gath. Les clés doivent provenir des données WH3 actuelles, pas d'une ancienne fixture du prototype.

--- a/tools/resolve_diplomatic_categories.py
+++ b/tools/resolve_diplomatic_categories.py
@@ -1,30 +1,111 @@
 #!/usr/bin/env python3
-"""Report direct faction-based diplomacy categories from exported WH3 tables."""
+"""Resolve faction diplomacy category rules from RPFM TSV exports.
+
+This deliberately reports rules and provenance; it does not invent a numeric
+turn-1 attitude. Culture/subculture expansion can be supplied when the matching
+criteria exports are available.
+"""
 import argparse, csv, json
 from collections import defaultdict
+from datetime import datetime, timezone
 from pathlib import Path
 
-PILOTS = ['wh2_dlc15_hef_imrik', 'wh_main_emp_reikland', 'wh2_dlc14_def_hag_graef', 'wh3_main_nur_poxmakers_of_nurgle']
+TABLES = {
+    'members': 'campaign_group_members_tables',
+    'factions': 'campaign_group_member_criteria_factions_tables',
+    'attitudes': 'campaign_group_member_criteria_diplomatic_attitudes_tables',
+}
 
-def rows(path):
-    with path.open(encoding='utf-8-sig', newline='') as f:
-        return [r for r in csv.DictReader(f, delimiter='\t') if not r.get('member', '').startswith('#')]
+
+def read_rows(path):
+    with path.open(encoding='utf-8-sig', newline='') as stream:
+        return [row for row in csv.DictReader(stream, delimiter='\t')
+                if not row.get('member', '').startswith('#')]
+
+
+def require_columns(rows, columns, label):
+    if not rows:
+        raise SystemExit(f'resolver failed: {label} export is empty')
+    missing = set(columns) - set(rows[0])
+    if missing:
+        raise SystemExit(f"resolver failed: {label} missing columns: {', '.join(sorted(missing))}")
+
 
 def main():
-    p = argparse.ArgumentParser(); p.add_argument('--db-dir', type=Path, required=True); p.add_argument('--output', type=Path, required=True); args = p.parse_args()
-    base = args.db_dir
-    files = {name: base / name / 'data__.tsv' for name in ['campaign_group_members_tables', 'campaign_group_member_criteria_factions_tables', 'campaign_group_member_criteria_diplomatic_attitudes_tables']}
-    if any(not path.is_file() for path in files.values()): raise SystemExit('resolver failed: missing required exported table')
-    group_for_member = {r['id']: r['group'] for r in rows(files['campaign_group_members_tables'])}
-    attitudes = {r['member']: r['attitude'] for r in rows(files['campaign_group_member_criteria_diplomatic_attitudes_tables'])}
-    categories = defaultdict(list)
-    for rule in rows(files['campaign_group_member_criteria_factions_tables']):
-        if rule['faction'] not in PILOTS: continue
-        group = group_for_member.get(rule['member'])
-        attitude = attitudes.get(rule['member'])
-        if group and attitude: categories[rule['faction']].append({'group': group, 'member': rule['member'], 'context': rule['context'], 'attitude': attitude, 'source': 'game-db'})
-    result = {'status': 'partial', 'scope': 'direct faction criteria only; culture/subculture and script precedence remain unresolved', 'factions': categories}
-    args.output.parent.mkdir(parents=True, exist_ok=True); args.output.write_text(json.dumps(result, ensure_ascii=False, indent=2)+'\n', encoding='utf-8')
-    print('resolved', sum(map(len, categories.values())), 'category rules')
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--db-dir', type=Path, required=True,
+                        help='Directory containing RPFM DB table export folders')
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--game-version', required=True)
+    parser.add_argument('--campaign', default='wh3_main_combi')
+    parser.add_argument('--factions', type=Path,
+                        help='Optional text file containing faction keys to keep, one per line')
+    args = parser.parse_args()
 
-if __name__ == '__main__': main()
+    paths = {key: args.db_dir / table / 'data__.tsv' for key, table in TABLES.items()}
+    missing = [str(path) for path in paths.values() if not path.is_file()]
+    if missing:
+        raise SystemExit('resolver failed: missing required exported table(s): ' + ', '.join(missing))
+
+    members = read_rows(paths['members'])
+    faction_rules = read_rows(paths['factions'])
+    attitude_rows = read_rows(paths['attitudes'])
+    require_columns(members, {'id', 'group'}, TABLES['members'])
+    require_columns(faction_rules, {'member', 'faction', 'context'}, TABLES['factions'])
+    require_columns(attitude_rows, {'member', 'attitude'}, TABLES['attitudes'])
+
+    wanted = None
+    if args.factions:
+        if not args.factions.is_file():
+            raise SystemExit(f'resolver failed: faction filter missing: {args.factions}')
+        wanted = {line.strip() for line in args.factions.read_text(encoding='utf-8').splitlines()
+                  if line.strip() and not line.lstrip().startswith('#')}
+
+    group_for_member = {row['id']: row['group'] for row in members}
+    attitudes = defaultdict(list)
+    for row in attitude_rows:
+        attitudes[row['member']].append(row['attitude'])
+
+    categories = defaultdict(list)
+    unresolved_members = set()
+    for rule in faction_rules:
+        faction = rule['faction']
+        if wanted is not None and faction not in wanted:
+            continue
+        member = rule['member']
+        group = group_for_member.get(member)
+        member_attitudes = attitudes.get(member, [])
+        if not group or not member_attitudes:
+            unresolved_members.add(member)
+            continue
+        for attitude in member_attitudes:
+            categories[faction].append({
+                'group': group,
+                'member': member,
+                'context': rule['context'],
+                'attitude': attitude,
+                'source': 'game-db',
+                'sourceTable': TABLES['attitudes'],
+            })
+
+    result = {
+        'gameVersion': args.game_version,
+        'campaign': args.campaign,
+        'generatedAt': datetime.now(timezone.utc).isoformat(),
+        'status': 'partial',
+        'scope': 'direct faction criteria; culture/subculture, faction-set expansion and campaign-script precedence remain separate inputs',
+        'sourceTables': list(TABLES.values()),
+        'factions': dict(sorted(categories.items())),
+        'diagnostics': {
+            'factionCount': len(categories),
+            'ruleCount': sum(len(items) for items in categories.values()),
+            'unresolvedMembers': sorted(unresolved_members),
+        },
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
+    print(f"resolved {result['diagnostics']['ruleCount']} direct rules for {len(categories)} factions")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Avance #1 et #5 sans fabriquer de scores.

- supprime la limitation codée en dur aux quatre factions pilotes ;
- permet de résoudre toutes les factions présentes dans les exports RPFM ;
- ajoute version du jeu, campagne, date et tables sources au rapport ;
- conserve la provenance de chaque règle ;
- ajoute des diagnostics pour les membres non résolus ;
- permet un filtre optionnel de factions pour les validations ciblées ;
- documente le pipeline Windows et l'ordre de reconstruction du tour 1.

Cette PR ne ferme pas #1/#5 : culture/sous-culture, faction sets, effets de faction et scripts doivent encore être intégrés avant de calculer une attitude complète.