### PR TITLE
feat: extraire les positions de départ depuis les scripts WH3

### DIFF
--- a/docs/start-position-extraction.md
+++ b/docs/start-position-extraction.md
@@ -1,0 +1,29 @@
+# Extraction des positions de départ Immortal Empires
+
+Les marqueurs cartographiques utilisent `cam_gameplay_start` provenant des scripts de campagne WH3. Ce sont des coordonnées de caméra de départ, pas des coordonnées de colonie.
+
+## Commande
+
+Exporter/copier les scripts de la campagne ciblée dans un répertoire local puis lancer, depuis PowerShell :
+
+```powershell
+python tools/import_campaign_start_positions.py `
+  --scripts-dir "C:\chemin\vers\script\campaign\main_warhammer" `
+  --game-version "<version WH3>" `
+  --campaign wh3_main_combi `
+  --output data/generated/immortal-empires-positions.json
+```
+
+Le scanner accepte les deux formes actuellement observées dans les scripts WH3 :
+
+- `local faction_key = "..."` suivi d'un `local cam_gameplay_start = {...}` ;
+- `<faction_key> = faction_intro_data:new{ ... cam_gameplay_start = {...} }`.
+
+## Garanties
+
+- chaque position conserve la liste des fichiers sources ;
+- aucune coordonnée n'est inventée ;
+- deux coordonnées différentes pour une même faction font échouer l'import afin d'éviter de mélanger plusieurs campagnes ;
+- un répertoire sans position exploitable fait également échouer l'import.
+
+Le JSON produit doit ensuite être relié au mapping `seigneur légendaire -> faction de départ`. La projection sur l'image inverse l'axe Y, car Y augmente vers le nord dans les coordonnées de campagne alors que `top` augmente vers le bas en CSS.

--- a/tools/import_campaign_start_positions.py
+++ b/tools/import_campaign_start_positions.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Extract verified WH3 cam_gameplay_start coordinates from campaign Lua scripts.
+
+The parser preserves the source file for every coordinate and refuses conflicting
+coordinates for the same faction instead of guessing which one is correct.
+"""
+import argparse
+import json
+import re
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+FACTION_LOCAL = re.compile(r'local\s+faction_key\s*=\s*["\'](?P<key>[a-zA-Z0-9_]+)["\']')
+FACTION_TABLE = re.compile(r'(?P<key>[a-zA-Z0-9_]+)\s*=\s*faction_intro_data\s*:\s*new\s*\{')
+CAMERA = re.compile(r'cam_gameplay_start\s*=\s*\{(?P<body>.*?)\}', re.DOTALL)
+NUMBER = r'[-+]?(?:\d+(?:\.\d*)?|\.\d+)'
+X_VALUE = re.compile(r'\bx\s*=\s*(?P<value>' + NUMBER + r')')
+Y_VALUE = re.compile(r'\by\s*=\s*(?P<value>' + NUMBER + r')')
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f'position import failed: {message}')
+
+
+def nearest_faction(prefix: str) -> str | None:
+    candidates: list[tuple[int, str]] = []
+    for pattern in (FACTION_LOCAL, FACTION_TABLE):
+        for match in pattern.finditer(prefix):
+            candidates.append((match.start(), match.group('key')))
+    return max(candidates, default=(-1, ''))[1] or None
+
+
+def extract_file(path: Path, root: Path) -> list[dict]:
+    text = path.read_text(encoding='utf-8-sig', errors='strict')
+    results = []
+    for camera in CAMERA.finditer(text):
+        faction = nearest_faction(text[max(0, camera.start() - 5000):camera.start()])
+        if not faction:
+            continue
+        body = camera.group('body')
+        x_match, y_match = X_VALUE.search(body), Y_VALUE.search(body)
+        if not x_match or not y_match:
+            continue
+        results.append({
+            'factionKey': faction,
+            'x': float(x_match.group('value')),
+            'y': float(y_match.group('value')),
+            'coordinateType': 'cam_gameplay_start',
+            'source': path.relative_to(root).as_posix(),
+        })
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--scripts-dir', type=Path, required=True,
+                        help='Campaign-specific WH3 script directory to scan recursively')
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--game-version', required=True)
+    parser.add_argument('--campaign', default='wh3_main_combi')
+    args = parser.parse_args()
+
+    root = args.scripts_dir.resolve()
+    if not root.is_dir():
+        fail(f'missing scripts directory: {args.scripts_dir}')
+
+    candidates: dict[str, list[dict]] = defaultdict(list)
+    scanned = 0
+    for path in sorted(root.rglob('*.lua')):
+        scanned += 1
+        for item in extract_file(path, root):
+            candidates[item['factionKey']].append(item)
+
+    if not candidates:
+        fail('no faction cam_gameplay_start coordinates found')
+
+    positions = []
+    conflicts = []
+    for faction, items in sorted(candidates.items()):
+        coordinates = {(item['x'], item['y']) for item in items}
+        if len(coordinates) > 1:
+            conflicts.append({'factionKey': faction, 'candidates': items})
+            continue
+        representative = items[0].copy()
+        representative['sources'] = sorted({item['source'] for item in items})
+        representative.pop('source')
+        positions.append(representative)
+
+    if conflicts:
+        details = ', '.join(item['factionKey'] for item in conflicts[:10])
+        fail(f'conflicting coordinates for {len(conflicts)} faction(s): {details}; use a campaign-specific script directory')
+
+    output = {
+        'gameVersion': args.game_version,
+        'campaign': args.campaign,
+        'generatedAt': datetime.now(timezone.utc).isoformat(),
+        'coordinateType': 'cam_gameplay_start',
+        'sourceRoot': root.name,
+        'scannedLuaFiles': scanned,
+        'positions': positions,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(output, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
+    print(f"generated {len(positions)} verified start positions from {scanned} Lua files")
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/test_import_campaign_start_positions.py
+++ b/tools/test_import_campaign_start_positions.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+import tempfile
+import unittest
+from pathlib import Path
+
+from import_campaign_start_positions import extract_file
+
+
+class StartPositionParserTests(unittest.TestCase):
+    def parse(self, content: str):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = root / 'start.lua'
+            path.write_text(content, encoding='utf-8')
+            return extract_file(path, root)
+
+    def test_local_faction_key_form(self):
+        rows = self.parse('''
+if cm:is_new_game() then
+  local faction_key = "wh3_dlc23_chd_zhatan";
+  local cam_gameplay_start = {
+    x = 525.1,
+    y = 114.1,
+    d = 11.8
+  };
+end;
+''')
+        self.assertEqual(1, len(rows))
+        self.assertEqual('wh3_dlc23_chd_zhatan', rows[0]['factionKey'])
+        self.assertEqual(525.1, rows[0]['x'])
+        self.assertEqual(114.1, rows[0]['y'])
+
+    def test_faction_intro_table_form(self):
+        rows = self.parse('''
+wh2_dlc15_hef_imrik = faction_intro_data:new{
+  cam_gameplay_start = {
+    x = 573.586609,
+    y = 330.326599,
+    d = 9
+  }
+}
+''')
+        self.assertEqual('wh2_dlc15_hef_imrik', rows[0]['factionKey'])
+        self.assertAlmostEqual(573.586609, rows[0]['x'])
+        self.assertAlmostEqual(330.326599, rows[0]['y'])
+
+    def test_unrelated_camera_without_faction_is_ignored(self):
+        rows = self.parse('cam_gameplay_start = {x=1,y=2}')
+        self.assertEqual([], rows)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Avance #10 et #5.

- ajoute un importeur récursif de `cam_gameplay_start` depuis les scripts Lua WH3 ;
- prend en charge les formes `local faction_key` et `faction_intro_data:new` ;
- conserve la provenance de chaque coordonnée ;
- échoue si plusieurs coordonnées contradictoires sont trouvées pour une même faction, au lieu de choisir arbitrairement ;
- ajoute des tests standard-library pour les deux syntaxes ;
- documente la commande PowerShell et l'inversion de l'axe Y pour la projection web.

#10 reste ouvert jusqu'à ce que le dataset généré couvre le roster jouable et soit consommé directement par le site.