### PR TITLE
feat: joindre les critères diplomatiques par membre

### DIFF
--- a/docs/diplomacy-extraction.md
+++ b/docs/diplomacy-extraction.md
@@ -8,14 +8,23 @@ Exporter au format TSV les tables suivantes en conservant la structure `db/<tabl
 
 - `campaign_group_members_tables`
 - `campaign_group_member_criteria_factions_tables`
+- `campaign_group_member_criteria_cultures_tables`
 - `campaign_group_member_criteria_diplomatic_attitudes_tables`
+- `factions_tables`
+- `cultures_subcultures_tables`
 - les tables startpos utilisées par `tools/import_start_pos.py`
 
-Les critères culture/sous-culture, faction sets et scripts de campagne sont des sources complémentaires : tant qu'ils ne sont pas résolus, le rapport reste `partial`.
+Les critères de faction sets, les éventuels critères de sous-culture supplémentaires, les effets de faction et les scripts de campagne restent des sources complémentaires : tant qu'ils ne sont pas résolus, le rapport reste `partial`.
+
+## Règle de modélisation importante
+
+Les lignes des tables `campaign_group_member_criteria_*` ne sont pas des modificateurs indépendants. Elles décrivent ensemble les critères d'un même `campaign_group_member`.
+
+Il faut donc conserver le `member` et le `context` (`ACTOR`, `RECIPIENT`, etc.) avant de reconstruire une relation directionnelle. Par exemple, une condition de faction côté acteur et une condition de culture côté destinataire peuvent appartenir au même membre. Les aplatir séparément produirait de faux résultats.
 
 ## Résolution des catégories directes
 
-Depuis PowerShell, à la racine du dépôt :
+Le resolver historique reste utile pour établir un rapport rapide des critères faction :
 
 ```powershell
 python tools/resolve_diplomatic_categories.py `
@@ -26,17 +35,39 @@ python tools/resolve_diplomatic_categories.py `
 
 Pour limiter temporairement l'analyse à un ensemble de factions, fournir un fichier texte contenant une clé de faction par ligne avec `--factions`.
 
-La sortie conserve la table source, le membre de groupe, le contexte et la catégorie d'attitude. Elle n'invente pas de valeur numérique.
+## Jointure correcte des membres diplomatiques
+
+Pour conserver ensemble attitude, critères de faction et critères de culture :
+
+```powershell
+python tools/resolve_diplomatic_members.py `
+  --db-dir data/raw/db `
+  --game-version "<version WH3>" `
+  --campaign wh3_main_combi `
+  --output data/generated/diplomatic-members.json
+```
+
+La sortie contient pour chaque membre :
+
+- son groupe ;
+- la ou les catégories d'attitude (`friendly`, `hostile`, etc.) ;
+- ses critères faction avec leur contexte ;
+- ses critères culture avec leur contexte ;
+- la liste des factions appartenant à chaque culture, reconstruite via `factions_tables` puis `cultures_subcultures_tables` ;
+- la provenance de chaque critère.
+
+Cette étape ne calcule volontairement aucun score numérique.
 
 ## Étapes de reconstruction du tour 1
 
 1. Extraire guerres et traités explicites du startpos.
-2. Résoudre les critères directs de faction.
-3. Étendre les critères de faction sets, culture et sous-culture.
-4. Appliquer les effets de faction qui modifient les relations diplomatiques.
-5. Inspecter les scripts de campagne pour les changements/forçages de diplomatie.
-6. Conserver la direction `sourceFaction -> targetFaction` à chaque étape.
-7. Produire le score seulement lorsque toutes les composantes nécessaires sont démontrées.
+2. Regrouper les critères par `campaign_group_member`.
+3. Résoudre faction, culture et sous-culture en conservant `ACTOR -> RECIPIENT`.
+4. Résoudre les faction sets sans casser la logique de membre.
+5. Appliquer les effets de faction qui modifient les relations diplomatiques.
+6. Inspecter les scripts de campagne pour les changements/forçages de diplomatie.
+7. Produire une relation `sourceFaction -> targetFaction` uniquement lorsque les critères du membre sont satisfaits.
+8. Produire un score seulement lorsque toutes les composantes nécessaires sont démontrées.
 
 ## Validation
 

--- a/tools/resolve_diplomatic_members.py
+++ b/tools/resolve_diplomatic_members.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Join WH3 diplomatic-attitude members with their faction/culture criteria.
+
+Campaign group criteria are attributes of a *member*. They must be kept together:
+for example an ACTOR faction criterion and a RECIPIENT culture criterion describe
+one directional diplomacy rule. This tool therefore does not flatten individual
+criteria into independent faction attitudes.
+"""
+import argparse
+import csv
+import json
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+TABLES = {
+    'members': 'campaign_group_members_tables',
+    'attitudes': 'campaign_group_member_criteria_diplomatic_attitudes_tables',
+    'factions': 'campaign_group_member_criteria_factions_tables',
+    'cultures': 'campaign_group_member_criteria_cultures_tables',
+    'faction_metadata': 'factions_tables',
+    'subculture_metadata': 'cultures_subcultures_tables',
+}
+
+
+def fail(message):
+    raise SystemExit(f'diplomatic member resolver failed: {message}')
+
+
+def read_table(path):
+    if not path.is_file():
+        fail(f'missing required export: {path}')
+    with path.open(encoding='utf-8-sig', newline='') as stream:
+        rows = list(csv.DictReader(stream, delimiter='\t'))
+    if not rows:
+        fail(f'empty export: {path}')
+    first_column = next(iter(rows[0]), None)
+    return [row for row in rows if not (first_column and row.get(first_column, '').startswith('#'))]
+
+
+def require(rows, columns, label):
+    if not rows:
+        fail(f'{label} has no data rows')
+    missing = set(columns) - set(rows[0])
+    if missing:
+        fail(f"{label} missing columns: {', '.join(sorted(missing))}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--db-dir', type=Path, required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--game-version', required=True)
+    parser.add_argument('--campaign', default='wh3_main_combi')
+    args = parser.parse_args()
+
+    paths = {name: args.db_dir / table / 'data__.tsv' for name, table in TABLES.items()}
+    rows = {name: read_table(path) for name, path in paths.items()}
+    require(rows['members'], {'id', 'group'}, TABLES['members'])
+    require(rows['attitudes'], {'member', 'attitude'}, TABLES['attitudes'])
+    require(rows['factions'], {'member', 'context', 'faction'}, TABLES['factions'])
+    require(rows['cultures'], {'member', 'context', 'culture'}, TABLES['cultures'])
+    require(rows['faction_metadata'], {'key', 'subculture'}, TABLES['faction_metadata'])
+    require(rows['subculture_metadata'], {'subculture', 'culture'}, TABLES['subculture_metadata'])
+
+    group_for_member = {row['id']: row['group'] for row in rows['members']}
+    faction_subculture = {row['key']: row['subculture'] for row in rows['faction_metadata'] if row['key']}
+    subculture_culture = {row['subculture']: row['culture'] for row in rows['subculture_metadata'] if row['subculture']}
+    factions_by_culture = defaultdict(list)
+    unresolved_subcultures = set()
+    for faction, subculture in faction_subculture.items():
+        culture = subculture_culture.get(subculture)
+        if culture:
+            factions_by_culture[culture].append(faction)
+        elif subculture:
+            unresolved_subcultures.add(subculture)
+
+    members = {}
+    for row in rows['attitudes']:
+        member = row['member']
+        item = members.setdefault(member, {
+            'member': member,
+            'group': group_for_member.get(member),
+            'attitudes': [],
+            'criteria': {'factions': [], 'cultures': []},
+        })
+        if row['attitude'] not in item['attitudes']:
+            item['attitudes'].append(row['attitude'])
+
+    for row in rows['factions']:
+        item = members.get(row['member'])
+        if not item:
+            continue
+        item['criteria']['factions'].append({
+            'context': row['context'],
+            'faction': row['faction'],
+            'sourceTable': TABLES['factions'],
+        })
+
+    unknown_cultures = set()
+    for row in rows['cultures']:
+        item = members.get(row['member'])
+        if not item:
+            continue
+        culture = row['culture']
+        matches = sorted(factions_by_culture.get(culture, []))
+        if not matches:
+            unknown_cultures.add(culture)
+        item['criteria']['cultures'].append({
+            'context': row['context'],
+            'culture': culture,
+            'matchingFactions': matches,
+            'sourceTable': TABLES['cultures'],
+        })
+
+    unresolved_groups = sorted(member for member, item in members.items() if not item['group'])
+    resolved = sorted(members.values(), key=lambda item: item['member'])
+    output = {
+        'gameVersion': args.game_version,
+        'campaign': args.campaign,
+        'generatedAt': datetime.now(timezone.utc).isoformat(),
+        'status': 'partial',
+        'semantics': 'criteria are grouped by campaign group member; contexts are preserved and are not treated as independent attitude modifiers',
+        'sourceTables': list(TABLES.values()),
+        'members': resolved,
+        'diagnostics': {
+            'attitudeMemberCount': len(resolved),
+            'membersWithFactionCriteria': sum(bool(item['criteria']['factions']) for item in resolved),
+            'membersWithCultureCriteria': sum(bool(item['criteria']['cultures']) for item in resolved),
+            'unresolvedMemberGroups': unresolved_groups,
+            'unknownCultures': sorted(unknown_cultures),
+            'unresolvedSubcultures': sorted(unresolved_subcultures),
+        },
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(output, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
+    print(f"joined {len(resolved)} diplomatic attitude members")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Avance #1/#5 en corrigeant le modèle de reconstruction.

- ajoute `resolve_diplomatic_members.py` ;
- conserve ensemble les critères appartenant au même `campaign_group_member` au lieu de traiter chaque ligne comme une attitude indépendante ;
- joint attitude, faction et culture avec leur `context` (`ACTOR`, `RECIPIENT`, etc.) ;
- reconstruit les factions correspondant à une culture via `factions_tables` et `cultures_subcultures_tables` ;
- conserve les tables sources et diagnostics ;
- ne calcule toujours aucun score non démontré ;
- documente cette sémantique pour la suite du pipeline.

#1/#5 restent ouverts : faction sets, effets de faction et scripts doivent encore être intégrés avant la résolution complète d'une paire.