### PR TITLE
feat: résoudre les cibles des effets diplomatiques WH3

### DIFF
--- a/docs/diplomacy-extraction.md
+++ b/docs/diplomacy-extraction.md
@@ -10,17 +10,26 @@ Exporter au format TSV les tables suivantes en conservant la structure `db/<tabl
 - `campaign_group_member_criteria_factions_tables`
 - `campaign_group_member_criteria_cultures_tables`
 - `campaign_group_member_criteria_diplomatic_attitudes_tables`
+- `effect_bonus_value_faction_junctions_tables`
+- `effect_bonus_value_subculture_junctions_tables`
 - `factions_tables`
 - `cultures_subcultures_tables`
 - les tables startpos utilisées par `tools/import_start_pos.py`
 
-Les critères de faction sets, les éventuels critères de sous-culture supplémentaires, les effets de faction et les scripts de campagne restent des sources complémentaires : tant qu'ils ne sont pas résolus, le rapport reste `partial`.
+Les critères de faction sets, les sources qui appliquent les valeurs des effets et les scripts de campagne restent des entrées complémentaires : tant qu'ils ne sont pas résolus, le rapport reste `partial`.
 
 ## Règle de modélisation importante
 
 Les lignes des tables `campaign_group_member_criteria_*` ne sont pas des modificateurs indépendants. Elles décrivent ensemble les critères d'un même `campaign_group_member`.
 
 Il faut donc conserver le `member` et le `context` (`ACTOR`, `RECIPIENT`, etc.) avant de reconstruire une relation directionnelle. Par exemple, une condition de faction côté acteur et une condition de culture côté destinataire peuvent appartenir au même membre. Les aplatir séparément produirait de faux résultats.
+
+De même, un effet diplomatique possède deux informations distinctes :
+
+1. la **valeur** appliquée (`+60`, `-60`, etc.), fournie par le bundle, trait, script ou autre source qui applique l'effet ;
+2. la **cible** de cette valeur, définie par les tables `effect_bonus_value_*_junctions`.
+
+Le pipeline ne doit jamais déduire l'une à partir de l'autre.
 
 ## Résolution des catégories directes
 
@@ -32,8 +41,6 @@ python tools/resolve_diplomatic_categories.py `
   --game-version "<version WH3>" `
   --output data/generated/diplomatic-categories.json
 ```
-
-Pour limiter temporairement l'analyse à un ensemble de factions, fournir un fichier texte contenant une clé de faction par ligne avec `--factions`.
 
 ## Jointure correcte des membres diplomatiques
 
@@ -47,16 +54,23 @@ python tools/resolve_diplomatic_members.py `
   --output data/generated/diplomatic-members.json
 ```
 
-La sortie contient pour chaque membre :
+Cette étape conserve les contextes et ne calcule volontairement aucun score numérique.
 
-- son groupe ;
-- la ou les catégories d'attitude (`friendly`, `hostile`, etc.) ;
-- ses critères faction avec leur contexte ;
-- ses critères culture avec leur contexte ;
-- la liste des factions appartenant à chaque culture, reconstruite via `factions_tables` puis `cultures_subcultures_tables` ;
-- la provenance de chaque critère.
+## Cibles des effets diplomatiques
 
-Cette étape ne calcule volontairement aucun score numérique.
+Pour reconstruire vers quelles factions s'applique un effet `faction_political_diplomacy_mod_*` :
+
+```powershell
+python tools/resolve_diplomatic_effect_targets.py `
+  --db-dir data/raw/db `
+  --game-version "<version WH3>" `
+  --campaign wh3_main_combi `
+  --output data/generated/diplomatic-effect-targets.json
+```
+
+Le resolver collecte les bonus `diplomatic_mod*` visant une faction ou une sous-culture. Une cible de sous-culture est développée en factions via `factions_tables`. La sortie ne contient pas de valeur : celle-ci devra être jointe ensuite avec la source qui applique l'effet.
+
+C'est notamment la couche nécessaire pour expliquer des effets de faction du type « relations diplomatiques +X avec une faction donnée » ou « -X avec une sous-culture donnée » sans encoder ces valeurs à la main.
 
 ## Étapes de reconstruction du tour 1
 
@@ -64,10 +78,10 @@ Cette étape ne calcule volontairement aucun score numérique.
 2. Regrouper les critères par `campaign_group_member`.
 3. Résoudre faction, culture et sous-culture en conservant `ACTOR -> RECIPIENT`.
 4. Résoudre les faction sets sans casser la logique de membre.
-5. Appliquer les effets de faction qui modifient les relations diplomatiques.
-6. Inspecter les scripts de campagne pour les changements/forçages de diplomatie.
-7. Produire une relation `sourceFaction -> targetFaction` uniquement lorsque les critères du membre sont satisfaits.
-8. Produire un score seulement lorsque toutes les composantes nécessaires sont démontrées.
+5. Résoudre les cibles des effets `diplomatic_mod*`.
+6. Retrouver les valeurs et les sources qui appliquent ces effets au tour 1.
+7. Inspecter les scripts de campagne pour les changements/forçages de diplomatie.
+8. Produire une relation `sourceFaction -> targetFaction` uniquement lorsque toutes ses composantes sont démontrées.
 
 ## Validation
 

--- a/tools/resolve_diplomatic_effect_targets.py
+++ b/tools/resolve_diplomatic_effect_targets.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Resolve which factions/subcultures a WH3 diplomatic effect targets.
+
+Effect values (for example +60 or -60) live in the source that applies the effect.
+The bonus-value junction tables describe *who that effect applies against*. This
+resolver keeps those two concerns separate so values are never guessed.
+"""
+import argparse
+import csv
+import json
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+TABLES = {
+    'faction_targets': 'effect_bonus_value_faction_junctions_tables',
+    'subculture_targets': 'effect_bonus_value_subculture_junctions_tables',
+    'factions': 'factions_tables',
+}
+
+
+def fail(message):
+    raise SystemExit(f'diplomatic effect resolver failed: {message}')
+
+
+def read(path):
+    if not path.is_file():
+        fail(f'missing required export: {path}')
+    with path.open(encoding='utf-8-sig', newline='') as stream:
+        rows = list(csv.DictReader(stream, delimiter='\t'))
+    if not rows:
+        fail(f'empty export: {path}')
+    first = next(iter(rows[0]), None)
+    return [row for row in rows if not (first and row.get(first, '').startswith('#'))]
+
+
+def require(rows, columns, label):
+    if not rows:
+        fail(f'{label} has no data rows')
+    missing = set(columns) - set(rows[0])
+    if missing:
+        fail(f"{label} missing columns: {', '.join(sorted(missing))}")
+
+
+def is_diplomacy_bonus(row):
+    return row.get('bonus_value_id', '').startswith('diplomatic_mod')
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--db-dir', type=Path, required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--game-version', required=True)
+    parser.add_argument('--campaign', default='wh3_main_combi')
+    args = parser.parse_args()
+
+    paths = {key: args.db_dir / table / 'data__.tsv' for key, table in TABLES.items()}
+    faction_rows = read(paths['faction_targets'])
+    subculture_rows = read(paths['subculture_targets'])
+    faction_metadata = read(paths['factions'])
+    require(faction_rows, {'bonus_value_id', 'effect', 'faction'}, TABLES['faction_targets'])
+    require(subculture_rows, {'bonus_value_id', 'effect', 'subculture'}, TABLES['subculture_targets'])
+    require(faction_metadata, {'key', 'subculture'}, TABLES['factions'])
+
+    factions_by_subculture = defaultdict(list)
+    for row in faction_metadata:
+        if row['key'] and row['subculture']:
+            factions_by_subculture[row['subculture']].append(row['key'])
+
+    effects = defaultdict(list)
+    for row in faction_rows:
+        if not is_diplomacy_bonus(row):
+            continue
+        effects[row['effect']].append({
+            'bonusValueId': row['bonus_value_id'],
+            'targetType': 'faction',
+            'target': row['faction'],
+            'matchingFactions': [row['faction']],
+            'sourceTable': TABLES['faction_targets'],
+        })
+
+    unknown_subcultures = set()
+    for row in subculture_rows:
+        if not is_diplomacy_bonus(row):
+            continue
+        matches = sorted(factions_by_subculture.get(row['subculture'], []))
+        if not matches:
+            unknown_subcultures.add(row['subculture'])
+        effects[row['effect']].append({
+            'bonusValueId': row['bonus_value_id'],
+            'targetType': 'subculture',
+            'target': row['subculture'],
+            'matchingFactions': matches,
+            'sourceTable': TABLES['subculture_targets'],
+        })
+
+    normalized = [
+        {'effect': effect, 'targets': targets}
+        for effect, targets in sorted(effects.items())
+    ]
+    result = {
+        'gameVersion': args.game_version,
+        'campaign': args.campaign,
+        'generatedAt': datetime.now(timezone.utc).isoformat(),
+        'status': 'partial',
+        'semantics': 'target metadata only; numeric values must come from the effect source/bundle/trait that applies each effect',
+        'sourceTables': list(TABLES.values()),
+        'effects': normalized,
+        'diagnostics': {
+            'effectCount': len(normalized),
+            'targetCount': sum(len(item['targets']) for item in normalized),
+            'unknownSubcultures': sorted(unknown_subcultures),
+        },
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
+    print(f"resolved {result['diagnostics']['targetCount']} diplomatic targets for {len(normalized)} effects")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Avance #1/#5 vers les effets de faction visibles dans l'interface WH3.

- ajoute un resolver des tables `effect_bonus_value_faction_junctions_tables` et `effect_bonus_value_subculture_junctions_tables` ;
- ne conserve que les bonus `diplomatic_mod*` ;
- distingue cible faction et cible sous-culture ;
- développe les sous-cultures en factions via `factions_tables` ;
- conserve la provenance et les diagnostics ;
- sépare explicitement la cible de l'effet de sa valeur numérique afin de ne rien inventer.

La prochaine étape est de retrouver, pour chaque effet pertinent au tour 1, la source qui l'applique et sa valeur (+60, -60, etc.), puis de joindre les deux.