### PR TITLE
feat: afficher la base culturelle diplomatique WH3

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,6 +23,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Import WH3 cultural diplomacy baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          WH3_DUMP_REF="61d4e117f669ea93d6da1077d1524c332d5e74c9"
+          mkdir -p .cache/wh3 data/generated
+          curl --fail --location --silent --show-error \
+            "https://raw.githubusercontent.com/Shazbot/WH3-Dump/${WH3_DUMP_REF}/db/campaign_cultural_relations_tables/data__.tsv" \
+            --output .cache/wh3/campaign_cultural_relations.tsv
+          python tools/import_cultural_relations.py \
+            --input .cache/wh3/campaign_cultural_relations.tsv \
+            --output data/generated/cultural-relations.json \
+            --campaign wh3_main_combi \
+            --game-version "WH3 data dump ${WH3_DUMP_REF}" \
+            --source-ref "Shazbot/WH3-Dump@${WH3_DUMP_REF}"
       - name: Setup Pages
         uses: actions/configure-pages@v5
         with:

--- a/cultural-relations.js
+++ b/cultural-relations.js
@@ -1,0 +1,98 @@
+(() => {
+  const raceToSubculture = {
+    "L'Empire": 'wh_main_sc_emp_empire',
+    'Nains': 'wh_main_sc_dwf_dwarfs',
+    'Hauts Elfes': 'wh2_main_sc_hef_high_elves',
+    'Elfes Noirs': 'wh2_main_sc_def_dark_elves',
+    'Hommes-lézards': 'wh2_main_sc_lzd_lizardmen',
+    'Skavens': 'wh2_main_sc_skv_skaven',
+    'Côte Vampire': 'wh2_dlc11_sc_cst_vampire_coast',
+    'Comtes Vampires': 'wh_main_sc_vmp_vampire_counts',
+    'Rois des Tombes': 'wh2_dlc09_sc_tmb_tomb_kings',
+    'Peaux-Vertes': 'wh_main_sc_grn_greenskins',
+    'Bretonnie': 'wh_main_sc_brt_bretonnia',
+    'Elfes Sylvains': 'wh_dlc05_sc_wef_wood_elves',
+    'Hommes-bêtes': 'wh_dlc03_sc_bst_beastmen',
+    'Norsca': 'wh_dlc08_sc_nor_norsca',
+    'Kislev': 'wh3_main_sc_ksl_kislev',
+    'Grand Cathay': 'wh3_main_sc_cth_cathay',
+    'Khorne': 'wh3_main_sc_kho_khorne',
+    'Nurgle': 'wh3_main_sc_nur_nurgle',
+    'Tzeentch': 'wh3_main_sc_tze_tzeentch',
+    'Slaanesh': 'wh3_main_sc_sla_slaanesh',
+    'Royaumes Ogres': 'wh3_main_sc_ogr_ogre_kingdoms',
+    'Nains du Chaos': 'wh3_dlc23_sc_chd_chaos_dwarfs',
+    'Guerriers du Chaos': 'wh_main_sc_chs_chaos',
+    'Démons du Chaos': 'wh3_main_sc_dae_daemons',
+  };
+
+  let culturalRelations = [];
+  let culturalMeta = null;
+
+  const originalRender = render;
+
+  function culturalRelation(from, to) {
+    const source = raceToSubculture[from.race];
+    const target = raceToSubculture[to.race];
+    if (!source || !target) return null;
+    return culturalRelations.find(r => r.sourceSubculture === source && r.targetSubculture === target) || null;
+  }
+
+  function scoreClass(value) {
+    if (value < 0) return 'cultural-negative';
+    if (value > 0) return 'cultural-positive';
+    return 'cultural-neutral';
+  }
+
+  function culturalCell(from, to) {
+    const explicit = from.key && to.key ? rel(from.key, to.key) : null;
+    const cultural = culturalRelation(from, to);
+    const culturalHtml = cultural
+      ? `<span class="cultural-score ${scoreClass(cultural.attitudeBase)}" title="Base culturelle WH3 : ${cultural.attitudeBase}; évolution négative ×${cultural.negativeAttitudeMultiplier}; évolution positive ×${cultural.positiveAttitudeMultiplier}">${cultural.attitudeBase > 0 ? '+' : ''}${cultural.attitudeBase}</span><small class="cultural-label">base culturelle</small>`
+      : '<span class="pending">Non extraite</span>';
+
+    if (!explicit) return culturalHtml;
+    if (explicit.atWar) return `<span class="bad">En guerre</span>${cultural ? `<small class="cultural-label">${cultural.attitudeBase > 0 ? '+' : ''}${cultural.attitudeBase} culturel</small>` : ''}`;
+    if (explicit.treaties?.length) return `<span>Traité</span>${cultural ? `<small class="cultural-label">${cultural.attitudeBase > 0 ? '+' : ''}${cultural.attitudeBase} culturel</small>` : ''}`;
+    return culturalHtml;
+  }
+
+  function renderCulturalMatrix() {
+    const ids = chosen();
+    const selectedLords = ids.map(id => lords.find(l => l.id === id)).filter(Boolean);
+    if (selectedLords.length < 2 || !culturalRelations.length) return;
+
+    matrix.innerHTML = '<table><tr><th>De / vers</th>' +
+      selectedLords.map(l => `<th>${l.name}</th>`).join('') + '</tr>' +
+      selectedLords.map(from => `<tr><th>${from.name}</th>` + selectedLords.map(to => {
+        if (from.id === to.id) return '<td>—</td>';
+        return `<td>${culturalCell(from, to)}</td>`;
+      }).join('') + '</tr>').join('') + '</table>' +
+      '<p class="source matrix-source">Valeurs numériques : <code>campaign_cultural_relations_tables.attitude_base</code>. Elles représentent la base culturelle directionnelle, avant les effets propres à la faction, les scripts et les événements.</p>';
+  }
+
+  render = function () {
+    originalRender();
+    renderCulturalMatrix();
+  };
+
+  const style = document.createElement('style');
+  style.textContent = `.cultural-score{display:block;font-weight:800;font-size:16px}.cultural-negative{color:var(--bad)}.cultural-positive{color:var(--good)}.cultural-neutral{color:var(--text)}.cultural-label{display:block;color:var(--muted);font-size:9px;margin-top:3px}.matrix-source{margin:10px 0 0;font-size:11px}`;
+  document.head.append(style);
+
+  fetch('./data/generated/cultural-relations.json')
+    .then(response => {
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      return response.json();
+    })
+    .then(data => {
+      culturalRelations = data.relations || [];
+      culturalMeta = data;
+      render();
+      const footer = document.querySelector('footer');
+      if (footer && culturalMeta) {
+        footer.textContent += ` · ${culturalRelations.length} relations culturelles directionnelles extraites`;
+      }
+    })
+    .catch(error => console.error('Impossible de charger la base culturelle WH3', error));
+})();

--- a/index.html
+++ b/index.html
@@ -26,5 +26,6 @@
   <footer>Données diplomatiques en cours de résolution.</footer>
 </main>
 <script src="roster.js"></script>
+<script src="cultural-relations.js"></script>
 </body>
 </html>

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,9 +1,20 @@
-# Import WH3
+# Outils d'import WH3
 
-Export the normalized diplomacy rows from RPFM as a TSV with `sourceFaction`, `targetFaction`, `modifierKey`, `value`, `source`, and `atWar` columns. Then run:
+Les scripts de ce dossier transforment des exports vanilla de Total War: WARHAMMER III en données traçables consommables par le site.
+
+## Base culturelle diplomatique
+
+`import_cultural_relations.py` importe `campaign_cultural_relations_tables` et produit les valeurs directionnelles `attitude_base` ainsi que les multiplicateurs positif/négatif. Ces valeurs constituent la base culturelle de l'attitude, pas le score diplomatique final.
+
+Exemple :
 
 ```powershell
-python tools/import_wh3.py --input exports/diplomacy.tsv --output data/generated/immortal-empires.json --game-version "WH3 <version>"
+python tools/import_cultural_relations.py `
+  --input data/raw/db/campaign_cultural_relations_tables/data__.tsv `
+  --output data/generated/cultural-relations.json `
+  --campaign wh3_main_combi `
+  --game-version "<version WH3>" `
+  --source-ref "RPFM export local"
 ```
 
-The importer fails when its input is missing, incomplete, or has an unknown provenance. It never substitutes or invents diplomacy values.
+Le déploiement GitHub Pages génère également ce dataset depuis une révision WH3-Dump épinglée afin que la matrice publique dispose de cette composante réelle.

--- a/tools/import_cultural_relations.py
+++ b/tools/import_cultural_relations.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Import WH3 campaign cultural relations into a compact directional JSON dataset."""
+import argparse
+import csv
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+REQUIRED = {
+    'campaign', 'source', 'target', 'attitude_base',
+    'negative_attitude_multiplier', 'positive_attitude_multiplier'
+}
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f'cultural relations import failed: {message}')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--input', type=Path, required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--campaign', default='wh3_main_combi')
+    parser.add_argument('--game-version', required=True)
+    parser.add_argument('--source-ref', required=True)
+    args = parser.parse_args()
+
+    if not args.input.is_file():
+        fail(f'missing TSV: {args.input}')
+
+    with args.input.open(encoding='utf-8-sig', newline='') as stream:
+        reader = csv.DictReader(stream, delimiter='\t')
+        if not reader.fieldnames or not REQUIRED.issubset(reader.fieldnames):
+            missing = REQUIRED - set(reader.fieldnames or [])
+            fail('missing columns: ' + ', '.join(sorted(missing)))
+        rows = [row for row in reader if row.get('source') and not row['source'].startswith('#')]
+
+    # Generic rows have an empty campaign. A campaign-specific row overrides the
+    # generic source -> target pair when present.
+    selected = {}
+    for row in rows:
+        campaign = (row.get('campaign') or '').strip()
+        if campaign not in ('', args.campaign):
+            continue
+        key = (row['source'], row['target'])
+        priority = 1 if campaign == args.campaign else 0
+        current = selected.get(key)
+        if current and current[0] > priority:
+            continue
+        selected[key] = (priority, {
+            'sourceSubculture': row['source'],
+            'targetSubculture': row['target'],
+            'attitudeBase': float(row['attitude_base']),
+            'negativeAttitudeMultiplier': float(row['negative_attitude_multiplier']),
+            'positiveAttitudeMultiplier': float(row['positive_attitude_multiplier']),
+            'campaign': campaign or None,
+            'source': 'game-db',
+            'sourceTable': 'campaign_cultural_relations_tables',
+        })
+
+    relations = [value[1] for _, value in sorted(selected.items())]
+    if not relations:
+        fail('no cultural relations matched the requested campaign')
+
+    output = {
+        'gameVersion': args.game_version,
+        'campaign': args.campaign,
+        'generatedAt': datetime.now(timezone.utc).isoformat(),
+        'sourceRef': args.source_ref,
+        'sourceTable': 'campaign_cultural_relations_tables',
+        'semantics': 'directional cultural baseline only; not the complete turn-1 diplomatic score',
+        'relations': relations,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(output, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
+    print(f'imported {len(relations)} directional cultural relations')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/test_import_cultural_relations.py
+++ b/tools/test_import_cultural_relations.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name('import_cultural_relations.py')
+
+
+class CulturalRelationsImporterTest(unittest.TestCase):
+    def test_campaign_specific_row_overrides_generic_row(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / 'relations.tsv'
+            output = root / 'out.json'
+            source.write_text(
+                'campaign\tsource\ttarget\tattitude_base\tnegative_attitude_multiplier\tpositive_attitude_multiplier\n'
+                '#campaign_cultural_relations_tables;0;db/campaign_cultural_relations_tables/data__\t\t\t\t\t\n'
+                '\twh2_main_sc_hef_high_elves\twh_main_sc_emp_empire\t0\t1\t1\n'
+                'wh3_main_combi\twh2_main_sc_hef_high_elves\twh_main_sc_emp_empire\t5\t1.1\t0.9\n'
+                'another_campaign\twh2_main_sc_hef_high_elves\twh2_main_sc_def_dark_elves\t-999\t2\t0.1\n',
+                encoding='utf-8',
+            )
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), '--input', str(source), '--output', str(output),
+                 '--campaign', 'wh3_main_combi', '--game-version', 'test', '--source-ref', 'fixture'],
+                check=False, capture_output=True, text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            data = json.loads(output.read_text(encoding='utf-8'))
+            self.assertEqual(len(data['relations']), 1)
+            relation = data['relations'][0]
+            self.assertEqual(relation['attitudeBase'], 5.0)
+            self.assertEqual(relation['negativeAttitudeMultiplier'], 1.1)
+            self.assertEqual(relation['positiveAttitudeMultiplier'], 0.9)
+            self.assertEqual(relation['campaign'], 'wh3_main_combi')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #19

Avance #1 et #5 avec une vraie donnée numérique issue de WH3.

- importe `campaign_cultural_relations_tables` depuis un commit WH3-Dump épinglé ;
- génère un dataset directionnel `sourceSubculture -> targetSubculture` au déploiement Pages ;
- affiche `attitude_base` dans la matrice pour les races/factions sélectionnées au lieu de `Non extraite` quand cette composante existe ;
- conserve la priorité visuelle aux guerres et traités explicites de départ ;
- affiche les multiplicateurs d'évolution positive/négative dans le tooltip ;
- étiquette explicitement ces nombres comme `base culturelle`, pas comme score diplomatique final ;
- ajoute un test sur la priorité des lignes spécifiques à Immortal Empires.

#1/#5 restent ouverts : il faut encore ajouter les effets propres aux factions, les bundles actifs au tour 1 et les changements scriptés pour obtenir le score final complet.