### PR TITLE
fix: charger les données WH3 et les positions du roster

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,12 +23,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Import WH3 cultural diplomacy baseline
+
+      - name: Import WH3 public datasets
         shell: bash
         run: |
           set -euo pipefail
           WH3_DUMP_REF="61d4e117f669ea93d6da1077d1524c332d5e74c9"
-          mkdir -p .cache/wh3 data/generated
+          GAME_VERSION="WH3 data dump ${WH3_DUMP_REF}"
+          SOURCE_REF="Shazbot/WH3-Dump@${WH3_DUMP_REF}"
+          mkdir -p .cache/wh3/scripts data/generated
+
           curl --fail --location --silent --show-error \
             "https://raw.githubusercontent.com/Shazbot/WH3-Dump/${WH3_DUMP_REF}/db/campaign_cultural_relations_tables/data__.tsv" \
             --output .cache/wh3/campaign_cultural_relations.tsv
@@ -36,8 +40,27 @@ jobs:
             --input .cache/wh3/campaign_cultural_relations.tsv \
             --output data/generated/cultural-relations.json \
             --campaign wh3_main_combi \
-            --game-version "WH3 data dump ${WH3_DUMP_REF}" \
-            --source-ref "Shazbot/WH3-Dump@${WH3_DUMP_REF}"
+            --game-version "${GAME_VERSION}" \
+            --source-ref "${SOURCE_REF}"
+
+          curl --fail --location --silent --show-error \
+            "https://raw.githubusercontent.com/Shazbot/WH3-Dump/${WH3_DUMP_REF}/db/frontend_faction_leaders_tables/data__.tsv" \
+            --output .cache/wh3/frontend_faction_leaders.tsv
+          python tools/import_frontend_leaders.py \
+            --input .cache/wh3/frontend_faction_leaders.tsv \
+            --output data/generated/frontend-leaders.json \
+            --game-version "${GAME_VERSION}" \
+            --source-ref "${SOURCE_REF}"
+
+          curl --fail --location --silent --show-error \
+            "https://raw.githubusercontent.com/Shazbot/WH3-Dump/${WH3_DUMP_REF}/script/campaign/main_warhammer/faction_intro/main_warhammer_faction_intro.lua" \
+            --output .cache/wh3/scripts/main_warhammer_faction_intro.lua
+          python tools/import_campaign_start_positions.py \
+            --scripts-dir .cache/wh3/scripts \
+            --output data/generated/campaign-start-positions.json \
+            --campaign wh3_main_combi \
+            --game-version "${GAME_VERSION}"
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
         with:

--- a/cultural-relations.js
+++ b/cultural-relations.js
@@ -49,7 +49,7 @@
     const cultural = culturalRelation(from, to);
     const culturalHtml = cultural
       ? `<span class="cultural-score ${scoreClass(cultural.attitudeBase)}" title="Base culturelle WH3 : ${cultural.attitudeBase}; évolution négative ×${cultural.negativeAttitudeMultiplier}; évolution positive ×${cultural.positiveAttitudeMultiplier}">${cultural.attitudeBase > 0 ? '+' : ''}${cultural.attitudeBase}</span><small class="cultural-label">base culturelle</small>`
-      : '<span class="pending">Non extraite</span>';
+      : '<span class="pending">Base culturelle non disponible</span>';
 
     if (!explicit) return culturalHtml;
     if (explicit.atWar) return `<span class="bad">En guerre</span>${cultural ? `<small class="cultural-label">${cultural.attitudeBase > 0 ? '+' : ''}${cultural.attitudeBase} culturel</small>` : ''}`;
@@ -68,7 +68,7 @@
         if (from.id === to.id) return '<td>—</td>';
         return `<td>${culturalCell(from, to)}</td>`;
       }).join('') + '</tr>').join('') + '</table>' +
-      '<p class="source matrix-source">Valeurs numériques : <code>campaign_cultural_relations_tables.attitude_base</code>. Elles représentent la base culturelle directionnelle, avant les effets propres à la faction, les scripts et les événements.</p>';
+      '<p class="source matrix-source">Valeurs numériques : <code>campaign_cultural_relations_tables.attitude_base</code>. Il s’agit de la base culturelle directionnelle du jeu, avant les effets propres à la faction, les scripts et les événements.</p>';
   }
 
   render = function () {
@@ -77,10 +77,10 @@
   };
 
   const style = document.createElement('style');
-  style.textContent = `.cultural-score{display:block;font-weight:800;font-size:16px}.cultural-negative{color:var(--bad)}.cultural-positive{color:var(--good)}.cultural-neutral{color:var(--text)}.cultural-label{display:block;color:var(--muted);font-size:9px;margin-top:3px}.matrix-source{margin:10px 0 0;font-size:11px}`;
+  style.textContent = `.cultural-score{display:block;font-weight:800;font-size:16px}.cultural-negative{color:var(--bad)}.cultural-positive{color:var(--good)}.cultural-neutral{color:var(--text)}.cultural-label{display:block;color:var(--muted);font-size:9px;margin-top:3px}.matrix-source{margin:10px 0 0;font-size:11px}.data-error{color:var(--bad);font-weight:700}`;
   document.head.append(style);
 
-  fetch('./data/generated/cultural-relations.json')
+  fetch('./data/generated/cultural-relations.json', { cache: 'no-store' })
     .then(response => {
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       return response.json();
@@ -91,8 +91,14 @@
       render();
       const footer = document.querySelector('footer');
       if (footer && culturalMeta) {
-        footer.textContent += ` · ${culturalRelations.length} relations culturelles directionnelles extraites`;
+        footer.textContent += ` · ${culturalRelations.length} bases culturelles directionnelles`;
       }
     })
-    .catch(error => console.error('Impossible de charger la base culturelle WH3', error));
+    .catch(error => {
+      console.error('Impossible de charger la base culturelle WH3', error);
+      const warning = document.createElement('p');
+      warning.className = 'source data-error';
+      warning.textContent = `Erreur de chargement des données diplomatiques (${error.message}).`;
+      matrix.after(warning);
+    });
 })();

--- a/index.html
+++ b/index.html
@@ -22,10 +22,10 @@
     <div class="selected" id="selected"></div>
   </section>
   <section class="panel"><h2>Compatibilité diplomatique</h2><div class="matrix" id="matrix"></div></section>
-  <section class="panel"><h2>Positions de départ</h2><div class="controls"><button id="minus">−</button><button id="reset">Recentrer</button><button id="plus">+</button></div><div class="map-viewport" id="mapViewport"><div class="map" id="map"></div></div><p class="source">Fond : carte Immortal Empires fournie pour le projet. Glisse pour déplacer, utilise +/− pour zoomer. Les marqueurs sont affichés uniquement pour les positions extraites et vérifiées.</p><p class="source" id="mapStatus"></p></section>
-  <footer>Données diplomatiques en cours de résolution.</footer>
+  <section class="panel"><h2>Positions de départ</h2><div class="controls"><button id="minus">−</button><button id="reset">Recentrer</button><button id="plus">+</button></div><div class="map-viewport" id="mapViewport"><div class="map" id="map"></div></div><p class="source">Fond : carte Immortal Empires fournie pour le projet. Glisse pour déplacer, utilise +/− pour zoomer. Les marqueurs sont calculés depuis les coordonnées <code>cam_gameplay_start</code> extraites des scripts WH3 ; aucun emplacement manquant n'est inventé.</p><p class="source" id="mapStatus"></p></section>
+  <footer>Chargement des données WH3…</footer>
 </main>
-<script src="roster.js"></script>
-<script src="cultural-relations.js"></script>
+<script src="roster.js?v=20260902-2"></script>
+<script src="cultural-relations.js?v=20260902-2"></script>
 </body>
 </html>

--- a/roster.js
+++ b/roster.js
@@ -25,11 +25,16 @@ const groups={
   "Démons du Chaos":[["daemon","Prince Démon","Légion du Chaos"]]
 };
 
-const factionKeys={imrik:'wh2_dlc15_hef_imrik',karl:'wh_main_emp_empire',malus:'wh2_main_def_hag_graef',kugath:'wh3_main_nur_poxmakers_of_nurgle'};
-const positions={imrik:[573.586609,330.326599],karl:[355.687042,487.026276],malus:[393.503754,719.28479],kugath:[668.102417,288.452148]};
-const lords=Object.entries(groups).flatMap(([race,a])=>a.map(([id,name,faction])=>({id,name,faction,race,key:factionKeys[id]})));
+const fallbackFactionKeys={imrik:'wh2_dlc15_hef_imrik',karl:'wh_main_emp_empire',malus:'wh2_main_def_hag_graef',kugath:'wh3_main_nur_poxmakers_of_nurgle'};
+const fallbackPositions={imrik:[573.586609,330.326599],karl:[355.687042,487.026276],malus:[393.503754,719.28479],kugath:[668.102417,288.452148]};
+const aliases={
+  karl:['karl','karl_franz'],kroq:['kroq','kroq_gar'],fay:['fay','fay_enchantress'],sisters:['sisters','sisters_of_twilight'],
+  kugath:['kugath','ku_gath'],nkari:['nkari','n_kari'],belakor:['belakor','be_lakor'],daemon:['daemon','daemon_prince']
+};
+const lords=Object.entries(groups).flatMap(([race,a])=>a.map(([id,name,faction])=>({id,name,faction,race,key:fallbackFactionKeys[id]||null})));
+const positions={...fallbackPositions};
 const roster=document.querySelector('#roster'),selected=document.querySelector('#selected'),matrix=document.querySelector('#matrix'),map=document.querySelector('#map'),mapViewport=document.querySelector('#mapViewport'),mapStatus=document.querySelector('#mapStatus'),search=document.querySelector('#search'),raceFilter=document.querySelector('#raceFilter');
-let relations=[],zoom=1,offset={x:0,y:0},drag=null;
+let relations=[],positionRecords=[],positionBounds=null,zoom=1,offset={x:0,y:0},drag=null,metadataLoading=true;
 const selectedIds=new Set(['imrik','karl']);
 const chosen=()=>[...selectedIds];
 
@@ -44,16 +49,29 @@ function renderRoster(){
 }
 function rel(a,b){return relations.find(r=>r.sourceFaction===a&&r.targetFaction===b)}
 function applyMapTransform(){map.style.transform=`translate(${offset.x}px,${offset.y}px) scale(${zoom})`}
+function calculateBounds(records){
+  if(!records.length)return null;
+  const xs=records.map(p=>p.x),ys=records.map(p=>p.y);
+  return {minX:Math.min(...xs),maxX:Math.max(...xs),minY:Math.min(...ys),maxY:Math.max(...ys)};
+}
+function mapPercent(x,y){
+  const b=positionBounds;
+  if(!b||b.maxX===b.minX||b.maxY===b.minY)return [50,50];
+  const pad=2.5;
+  return [pad+(x-b.minX)/(b.maxX-b.minX)*(100-pad*2),pad+(b.maxY-y)/(b.maxY-b.minY)*(100-pad*2)];
+}
 function renderMap(ids){
   map.innerHTML='';let missing=0;
   ids.forEach(id=>{
     if(!positions[id]){missing++;return}
     const l=lords.find(x=>x.id===id),[x,y]=positions[id],m=document.createElement('div');m.className='marker';
-    const left=8+(x-250)/500*84,top=8+(780-y)/580*84;
-    m.style.left=`${Math.max(3,Math.min(97,left))}%`;m.style.top=`${Math.max(3,Math.min(97,top))}%`;
+    const [left,top]=mapPercent(x,y);
+    m.style.left=`${left}%`;m.style.top=`${top}%`;
     m.innerHTML=`<span class="marker-dot"></span><span class="marker-label"><b>${l.name}</b><small>${l.faction}</small></span>`;map.append(m);
   });
-  mapStatus.textContent=missing?`${missing} position(s) sélectionnée(s) restent à extraire. Aucun emplacement approximatif n'est affiché.`:'Toutes les positions sélectionnées sont issues de coordonnées WH3 vérifiées.';
+  if(metadataLoading)mapStatus.textContent='Chargement des positions WH3 vérifiées…';
+  else if(missing)mapStatus.textContent=`${missing} position(s) sélectionnée(s) non résolue(s) dans le dump courant. Aucun emplacement approximatif n'est inventé.`;
+  else mapStatus.textContent='Toutes les positions sélectionnées proviennent de cam_gameplay_start dans les scripts WH3.';
   applyMapTransform();
 }
 function renderSelected(ids){
@@ -64,8 +82,44 @@ function render(){
   const ids=chosen(),a=ids.map(id=>lords.find(l=>l.id===id)).filter(Boolean);
   renderSelected(ids);renderMap(ids);
   if(ids.length<2){matrix.innerHTML='<p class="pending">Sélectionne au moins deux dirigeants.</p>';return}
-  matrix.innerHTML='<table><tr><th>De / vers</th>'+a.map(l=>`<th>${l.name}</th>`).join('')+'</tr>'+a.map(x=>`<tr><th>${x.name}</th>`+a.map(y=>{if(x.id===y.id)return'<td>—</td>';const r=x.key&&y.key?rel(x.key,y.key):null;return r?`<td class="${r.atWar?'bad':''}">${r.atWar?'En guerre':r.treaties.length?'Traité':'Relation explicite'}</td>`:'<td class="pending">Non extraite</td>'}).join('')+'</tr>').join('')+'</table>';
+  matrix.innerHTML='<table><tr><th>De / vers</th>'+a.map(l=>`<th>${l.name}</th>`).join('')+'</tr>'+a.map(x=>`<tr><th>${x.name}</th>`+a.map(y=>{
+    if(x.id===y.id)return'<td>—</td>';
+    const r=x.key&&y.key?rel(x.key,y.key):null;
+    return r?`<td class="${r.atWar?'bad':''}">${r.atWar?'En guerre':r.treaties.length?'Traité':'Relation explicite'}</td>`:'<td class="pending">Pas de relation explicite</td>';
+  }).join('')+'</tr>').join('')+'</table>';
 }
+function words(value){return String(value||'').toLowerCase().split(/[^a-z0-9]+/).filter(Boolean)}
+function scoreLeaderMatch(row,id){
+  const wanted=aliases[id]||[id];
+  const fields=[[row.agentSubtype,30],[row.politicalPartyKey,20],[row.factionKey,10]];
+  let best=0;
+  for(const alias of wanted){
+    const aliasWords=words(alias);
+    for(const [value,weight] of fields){
+      const valueWords=words(value);
+      if(aliasWords.length===1&&valueWords.includes(aliasWords[0]))best=Math.max(best,weight);
+      else if(aliasWords.length>1&&aliasWords.every(word=>valueWords.includes(word)))best=Math.max(best,weight+1);
+    }
+  }
+  return best;
+}
+function applyLeaderMetadata(frontendData,startData){
+  const rows=frontendData?.leaders||[];
+  positionRecords=startData?.positions||[];
+  positionBounds=calculateBounds(positionRecords);
+  const byFaction=new Map(positionRecords.map(p=>[p.factionKey,p]));
+  for(const lord of lords){
+    const ranked=rows.map(row=>({row,score:scoreLeaderMatch(row,lord.id)})).filter(x=>x.score>0).sort((a,b)=>b.score-a.score);
+    if(ranked.length&&(!ranked[1]||ranked[0].score>ranked[1].score||ranked[0].row.factionKey===ranked[1].row.factionKey))lord.key=ranked[0].row.factionKey;
+    const pos=lord.key?byFaction.get(lord.key):null;
+    if(pos)positions[lord.id]=[pos.x,pos.y];
+  }
+}
+function setFooter(){
+  const keyed=lords.filter(l=>l.key).length,located=lords.filter(l=>positions[l.id]).length;
+  document.querySelector('footer').textContent=`Roster ${lords.length} seigneurs · ${keyed} factions résolues · ${located} positions de départ résolues · ${relations.length} relations explicites`;
+}
+
 roster.addEventListener('change',e=>{if(!e.target.matches('input[type="checkbox"]'))return;e.target.checked?selectedIds.add(e.target.value):selectedIds.delete(e.target.value);render()});
 selected.addEventListener('click',e=>{const button=e.target.closest('[data-remove]');if(!button)return;selectedIds.delete(button.dataset.remove);renderRoster();render()});
 raceFilter.onchange=()=>{search.value='';renderRoster()};
@@ -77,5 +131,15 @@ mapViewport.addEventListener('pointerdown',e=>{drag={x:e.clientX,y:e.clientY,ox:
 mapViewport.addEventListener('pointermove',e=>{if(!drag)return;offset={x:drag.ox+e.clientX-drag.x,y:drag.oy+e.clientY-drag.y};applyMapTransform()});
 mapViewport.addEventListener('pointerup',()=>{drag=null;mapViewport.classList.remove('dragging')});
 mapViewport.addEventListener('pointercancel',()=>{drag=null;mapViewport.classList.remove('dragging')});
-initRaceFilter();renderRoster();
-fetch('./data/generated/immortal-empires-startpos.json').then(r=>r.json()).then(d=>{relations=d.relations;document.querySelector('footer').textContent=`Roster ${lords.length} seigneurs · Dataset ${d.gameVersion} · ${d.relations.length} relations explicites · attitudes en cours de résolution`;render()}).catch(render);render();
+
+initRaceFilter();renderRoster();render();
+Promise.allSettled([
+  fetch('./data/generated/immortal-empires-startpos.json',{cache:'no-store'}).then(r=>{if(!r.ok)throw new Error(`relations HTTP ${r.status}`);return r.json()}),
+  fetch('./data/generated/frontend-leaders.json',{cache:'no-store'}).then(r=>{if(!r.ok)throw new Error(`leaders HTTP ${r.status}`);return r.json()}),
+  fetch('./data/generated/campaign-start-positions.json',{cache:'no-store'}).then(r=>{if(!r.ok)throw new Error(`positions HTTP ${r.status}`);return r.json()})
+]).then(([relationsResult,leadersResult,positionsResult])=>{
+  if(relationsResult.status==='fulfilled')relations=relationsResult.value.relations||[];
+  if(leadersResult.status==='fulfilled'&&positionsResult.status==='fulfilled')applyLeaderMetadata(leadersResult.value,positionsResult.value);
+  else console.error('Métadonnées de factions/positions incomplètes',leadersResult,positionsResult);
+  metadataLoading=false;setFooter();render();
+});

--- a/tools/import_campaign_start_positions.py
+++ b/tools/import_campaign_start_positions.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Extract verified WH3 cam_gameplay_start coordinates from campaign Lua scripts.
 
-The parser preserves the source file for every coordinate and refuses conflicting
-coordinates for the same faction instead of guessing which one is correct.
+The parser preserves the source file for every coordinate. Conflicting coordinates
+are excluded from the generated positions dataset and reported separately, so the
+site can keep all unambiguous positions without ever guessing an ambiguous one.
 """
 import argparse
 import json
@@ -59,6 +60,8 @@ def main() -> None:
     parser.add_argument('--output', type=Path, required=True)
     parser.add_argument('--game-version', required=True)
     parser.add_argument('--campaign', default='wh3_main_combi')
+    parser.add_argument('--fail-on-conflict', action='store_true',
+                        help='Fail instead of excluding factions that have conflicting coordinates')
     args = parser.parse_args()
 
     root = args.scripts_dir.resolve()
@@ -87,9 +90,9 @@ def main() -> None:
         representative.pop('source')
         positions.append(representative)
 
-    if conflicts:
+    if conflicts and args.fail_on_conflict:
         details = ', '.join(item['factionKey'] for item in conflicts[:10])
-        fail(f'conflicting coordinates for {len(conflicts)} faction(s): {details}; use a campaign-specific script directory')
+        fail(f'conflicting coordinates for {len(conflicts)} faction(s): {details}')
 
     output = {
         'gameVersion': args.game_version,
@@ -99,10 +102,11 @@ def main() -> None:
         'sourceRoot': root.name,
         'scannedLuaFiles': scanned,
         'positions': positions,
+        'conflicts': conflicts,
     }
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(output, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
-    print(f"generated {len(positions)} verified start positions from {scanned} Lua files")
+    print(f"generated {len(positions)} verified start positions from {scanned} Lua files; excluded {len(conflicts)} conflicting faction(s)")
 
 
 if __name__ == '__main__':

--- a/tools/import_frontend_leaders.py
+++ b/tools/import_frontend_leaders.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Import WH3 frontend faction leaders into a compact faction lookup dataset."""
+import argparse
+import csv
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+REQUIRED = {'key', 'agent_subtype_record', 'faction'}
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f'frontend leader import failed: {message}')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--input', type=Path, required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--game-version', required=True)
+    parser.add_argument('--source-ref', required=True)
+    args = parser.parse_args()
+
+    if not args.input.is_file():
+        fail(f'missing TSV: {args.input}')
+
+    with args.input.open(encoding='utf-8-sig', newline='') as stream:
+        reader = csv.DictReader(stream, delimiter='\t')
+        fields = set(reader.fieldnames or [])
+        if not REQUIRED.issubset(fields):
+            fail('missing columns: ' + ', '.join(sorted(REQUIRED - fields)))
+        leaders = []
+        for row in reader:
+            key = (row.get('key') or '').strip()
+            agent = (row.get('agent_subtype_record') or '').strip()
+            faction = (row.get('faction') or '').strip()
+            if not key or key.startswith('#') or not agent or not faction:
+                continue
+            leaders.append({
+                'politicalPartyKey': key,
+                'agentSubtype': agent,
+                'factionKey': faction,
+            })
+
+    if not leaders:
+        fail('no playable frontend leaders found')
+
+    unique = {(item['politicalPartyKey'], item['agentSubtype'], item['factionKey']): item for item in leaders}
+    output = {
+        'gameVersion': args.game_version,
+        'generatedAt': datetime.now(timezone.utc).isoformat(),
+        'sourceRef': args.source_ref,
+        'sourceTable': 'frontend_faction_leaders_tables',
+        'leaders': [unique[key] for key in sorted(unique)],
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(output, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
+    print(f"imported {len(output['leaders'])} frontend faction leaders")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Corrige les deux problèmes visibles sur GitHub Pages : la matrice restait sur « Non extraite » et les marqueurs de départ étaient limités au petit pilote.

- génère à chaque déploiement la base culturelle directionnelle WH3 ;
- génère le mapping officiel dirigeant jouable → faction depuis `frontend_faction_leaders_tables` ;
- extrait automatiquement les `cam_gameplay_start` du script Immortal Empires ;
- résout le roster vers les factions et les positions sans inventer les cas ambigus ;
- exclut les coordonnées conflictuelles au lieu de faire échouer tout le dataset ;
- désactive le cache sur les JSON et versionne les scripts Pages pour éviter d'afficher les anciens assets ;
- affiche explicitement une erreur si les données diplomatiques ne se chargent pas.

Les nombres affichés restent volontairement la **base culturelle directionnelle** de `campaign_cultural_relations_tables`, pas un faux score complet de tour 1.

Refs #5 #6 #7