### PR TITLE
feat: résoudre les valeurs numériques des effets diplomatiques

### DIFF
--- a/tools/resolve_diplomatic_effect_values.py
+++ b/tools/resolve_diplomatic_effect_values.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Join WH3 diplomatic effect target metadata with numeric effect-bundle values.
+
+This does not claim a faction owns a bundle. It only answers:
+- which diplomatic effect a bundle contains,
+- its numeric value/scope,
+- which factions/subcultures that effect targets.
+
+The separate source-assignment step is still required before adding a modifier to a
+specific faction's turn-1 attitude.
+"""
+import argparse
+import csv
+import json
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def fail(message):
+    raise SystemExit(f'diplomatic effect value resolver failed: {message}')
+
+
+def read_tsv(path):
+    if not path.is_file():
+        fail(f'missing export: {path}')
+    with path.open(encoding='utf-8-sig', newline='') as stream:
+        rows = list(csv.DictReader(stream, delimiter='\t'))
+    if not rows:
+        fail(f'empty export: {path}')
+    first = next(iter(rows[0]), None)
+    return [row for row in rows if not (first and row.get(first, '').startswith('#'))]
+
+
+def require(rows, columns, label):
+    missing = set(columns) - set(rows[0])
+    if missing:
+        fail(f"{label} missing columns: {', '.join(sorted(missing))}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--bundles', type=Path, required=True,
+                        help='effect_bundles_to_effects_junctions_tables/data__.tsv')
+    parser.add_argument('--targets', type=Path, required=True,
+                        help='JSON produced by resolve_diplomatic_effect_targets.py')
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--game-version', required=True)
+    parser.add_argument('--campaign', default='wh3_main_combi')
+    args = parser.parse_args()
+
+    rows = read_tsv(args.bundles)
+    require(rows, {'effect_bundle_key', 'effect_key', 'effect_scope', 'value'}, 'effect bundle junctions')
+    if not args.targets.is_file():
+        fail(f'missing target report: {args.targets}')
+    target_data = json.loads(args.targets.read_text(encoding='utf-8'))
+    targets_by_effect = {item['effect']: item.get('targets', []) for item in target_data.get('effects', [])}
+
+    bundles = defaultdict(list)
+    for row in rows:
+        effect = row['effect_key']
+        targets = targets_by_effect.get(effect)
+        if not targets:
+            continue
+        try:
+            value = float(row['value'])
+        except ValueError:
+            fail(f"invalid numeric value {row['value']!r} for {row['effect_bundle_key']} / {effect}")
+        bundles[row['effect_bundle_key']].append({
+            'effect': effect,
+            'scope': row['effect_scope'],
+            'value': value,
+            'advancementStage': row.get('advancement_stage') or None,
+            'targets': targets,
+            'sourceTable': 'effect_bundles_to_effects_junctions_tables',
+        })
+
+    normalized = [
+        {'effectBundle': key, 'diplomaticEffects': effects}
+        for key, effects in sorted(bundles.items())
+    ]
+    output = {
+        'gameVersion': args.game_version,
+        'campaign': args.campaign,
+        'generatedAt': datetime.now(timezone.utc).isoformat(),
+        'status': 'partial',
+        'semantics': 'numeric bundle effects plus verified targets; source-faction ownership/application is not resolved here',
+        'sourceTables': [
+            'effect_bundles_to_effects_junctions_tables',
+            *target_data.get('sourceTables', []),
+        ],
+        'effectBundles': normalized,
+        'diagnostics': {
+            'bundleCount': len(normalized),
+            'effectCount': sum(len(item['diplomaticEffects']) for item in normalized),
+        },
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(output, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
+    print(f"resolved {output['diagnostics']['effectCount']} diplomatic bundle effects in {len(normalized)} bundles")
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/test_resolve_diplomatic_effect_values.py
+++ b/tools/test_resolve_diplomatic_effect_values.py
@@ -1,0 +1,47 @@
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def test_resolver_joins_values_and_targets():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        bundles = root / 'bundles.tsv'
+        targets = root / 'targets.json'
+        output = root / 'out.json'
+        bundles.write_text(
+            'effect_bundle_key\teffect_key\teffect_scope\tvalue\tadvancement_stage\n'
+            '#meta\t\t\t\t\n'
+            'bundle_a\teffect_diplomacy\tfaction_to_faction_own\t60.0000\tstart_turn_completed\n'
+            'bundle_a\teffect_unrelated\tfaction_to_faction_own\t5.0000\tstart_turn_completed\n',
+            encoding='utf-8',
+        )
+        targets.write_text(json.dumps({
+            'sourceTables': ['effect_bonus_value_faction_junctions_tables'],
+            'effects': [{
+                'effect': 'effect_diplomacy',
+                'targets': [{
+                    'bonusValueId': 'diplomatic_mod',
+                    'targetType': 'faction',
+                    'target': 'target_faction',
+                    'matchingFactions': ['target_faction'],
+                }],
+            }],
+        }), encoding='utf-8')
+
+        subprocess.run([
+            sys.executable,
+            str(Path(__file__).with_name('resolve_diplomatic_effect_values.py')),
+            '--bundles', str(bundles),
+            '--targets', str(targets),
+            '--output', str(output),
+            '--game-version', 'test',
+        ], check=True)
+
+        data = json.loads(output.read_text(encoding='utf-8'))
+        assert data['diagnostics'] == {'bundleCount': 1, 'effectCount': 1}
+        effect = data['effectBundles'][0]['diplomaticEffects'][0]
+        assert effect['value'] == 60.0
+        assert effect['targets'][0]['target'] == 'target_faction'


### PR DESCRIPTION
Avance #1 et #5.

- ajoute un resolver qui joint les cibles diplomatiques déjà identifiées aux valeurs numériques de `effect_bundles_to_effects_junctions_tables` ;
- conserve la portée (`effect_scope`) et l'étape d'avancement ;
- n'attribue pas encore un bundle à une faction source tant que cette application n'est pas démontrée ;
- ajoute un test reproductible avec une valeur +60.

Cette PR permet désormais de reconstruire correctement la couche « effet diplomatique +60/-60 -> cibles », sans encore prétendre qu'un effet appartient à une faction donnée au tour 1. #1/#5 restent ouverts.