### PR TITLE
feat: extraire les sources de bundles depuis les scripts WH3

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -88,13 +88,25 @@ jobs:
             --campaign wh3_main_combi \
             --game-version "${GAME_VERSION}"
 
+          git clone --filter=blob:none --no-checkout --quiet \
+            https://github.com/Shazbot/WH3-Dump.git .cache/wh3-dump
+          git -C .cache/wh3-dump sparse-checkout init --cone
+          git -C .cache/wh3-dump sparse-checkout set script/campaign
+          git -C .cache/wh3-dump checkout --quiet "${WH3_DUMP_REF}"
+          python tools/resolve_script_effect_bundle_sources.py \
+            --scripts-dir .cache/wh3-dump/script/campaign \
+            --output data/generated/script-effect-bundle-sources.json \
+            --campaign wh3_main_combi \
+            --game-version "${GAME_VERSION}"
+
           for file in \
             immortal-empires-startpos.json \
             frontend-leaders.json \
             campaign-start-positions.json \
             cultural-relations.json \
             diplomatic-effect-targets.json \
-            diplomatic-effect-values.json; do
+            diplomatic-effect-values.json \
+            script-effect-bundle-sources.json; do
             cp "data/generated/${file}" "data/runtime/${file}"
           done
 
@@ -116,7 +128,8 @@ jobs:
             data/generated/campaign-start-positions.json \
             data/generated/cultural-relations.json \
             data/generated/diplomatic-effect-targets.json \
-            data/generated/diplomatic-effect-values.json; do
+            data/generated/diplomatic-effect-values.json \
+            data/generated/script-effect-bundle-sources.json; do
             if ! git ls-files --error-unmatch "$file" >/dev/null 2>&1; then
               git add "$file"
               changed=1

--- a/tools/resolve_script_effect_bundle_sources.py
+++ b/tools/resolve_script_effect_bundle_sources.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Extract conservative faction -> effect bundle assignments from WH3 Lua scripts.
+
+Only statically provable `cm:apply_effect_bundle(...)` calls are emitted. The
+resolver accepts a literal bundle key and resolves the faction argument when it
+is either a literal faction key or a variable that has exactly one literal
+assignment in the same file. Dynamic concatenations and ambiguous variables are
+reported but never guessed.
+"""
+import argparse
+import json
+import re
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+STRING = r'(["\'])(.*?)\1'
+ASSIGN_RE = re.compile(r'(?m)^\s*(?:local\s+)?([A-Za-z_][A-Za-z0-9_\.]*)\s*=\s*(["\'])([^"\']+)\2\s*;?\s*(?:--.*)?$')
+CALL_RE = re.compile(
+    r'cm:apply_effect_bundle\(\s*(["\'])([^"\']+)\1\s*,\s*([^,\)]+)\s*,\s*([^\)]+)\)',
+    re.MULTILINE,
+)
+FACTION_KEY_RE = re.compile(r'^(?:wh|wh2|wh3)_[a-z0-9_]+$')
+
+
+def resolve_arg(expr, assignments):
+    expr = expr.strip()
+    literal = re.fullmatch(r'(["\'])([^"\']+)\1', expr)
+    if literal:
+        return literal.group(2), 'literal'
+    values = assignments.get(expr, set())
+    if len(values) == 1:
+        return next(iter(values)), 'single-file-constant'
+    return None, 'dynamic-or-ambiguous'
+
+
+def scan_file(path, root):
+    text = path.read_text(encoding='utf-8', errors='replace')
+    assignments = defaultdict(set)
+    for match in ASSIGN_RE.finditer(text):
+        assignments[match.group(1)].add(match.group(3))
+
+    resolved = []
+    unresolved = []
+    for match in CALL_RE.finditer(text):
+        bundle = match.group(2)
+        faction_expr = match.group(3).strip()
+        turns_expr = match.group(4).strip()
+        faction, resolution = resolve_arg(faction_expr, assignments)
+        line = text.count('\n', 0, match.start()) + 1
+        source = str(path.relative_to(root)).replace('\\', '/')
+        if faction and FACTION_KEY_RE.match(faction):
+            resolved.append({
+                'faction': faction,
+                'effectBundle': bundle,
+                'turnsExpression': turns_expr,
+                'resolution': resolution,
+                'sourceFile': source,
+                'sourceLine': line,
+            })
+        else:
+            unresolved.append({
+                'effectBundle': bundle,
+                'factionExpression': faction_expr,
+                'turnsExpression': turns_expr,
+                'reason': resolution if faction is None else 'resolved-value-is-not-a-faction-key',
+                'sourceFile': source,
+                'sourceLine': line,
+            })
+    return resolved, unresolved
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--scripts-dir', type=Path, required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--game-version', required=True)
+    parser.add_argument('--campaign', default='wh3_main_combi')
+    args = parser.parse_args()
+
+    if not args.scripts_dir.is_dir():
+        raise SystemExit(f'script source resolver failed: missing scripts dir {args.scripts_dir}')
+
+    resolved, unresolved = [], []
+    files = sorted(args.scripts_dir.rglob('*.lua'))
+    for path in files:
+        r, u = scan_file(path, args.scripts_dir)
+        resolved.extend(r)
+        unresolved.extend(u)
+
+    dedup = {}
+    for item in resolved:
+        key = (item['faction'], item['effectBundle'], item['sourceFile'], item['sourceLine'])
+        dedup[key] = item
+    resolved = sorted(dedup.values(), key=lambda x: (x['faction'], x['effectBundle'], x['sourceFile'], x['sourceLine']))
+
+    output = {
+        'gameVersion': args.game_version,
+        'campaign': args.campaign,
+        'generatedAt': datetime.now(timezone.utc).isoformat(),
+        'status': 'partial',
+        'semantics': 'static script assignments only; presence in scripts does not imply the bundle is active on turn 1 unless the call executes during campaign initialisation',
+        'assignments': resolved,
+        'diagnostics': {
+            'luaFilesScanned': len(files),
+            'resolvedAssignments': len(resolved),
+            'unresolvedCalls': len(unresolved),
+            'unresolved': unresolved,
+        },
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(output, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
+    print(f"resolved {len(resolved)} static faction/bundle assignments from {len(files)} Lua files")
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/test_resolve_script_effect_bundle_sources.py
+++ b/tools/test_resolve_script_effect_bundle_sources.py
@@ -1,0 +1,36 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_static_script_bundle_sources(tmp_path):
+    scripts = tmp_path / 'scripts'
+    scripts.mkdir()
+    (scripts / 'sample.lua').write_text(
+        '''
+local faction_key = "wh3_main_ksl_the_ice_court"
+cm:apply_effect_bundle("bundle_literal", "wh_main_emp_empire", 0)
+cm:apply_effect_bundle("bundle_variable", faction_key, -1)
+local ambiguous = "wh2_main_hef_eataine"
+ambiguous = "wh2_main_hef_avelorn"
+cm:apply_effect_bundle("bundle_ambiguous", ambiguous, 3)
+cm:apply_effect_bundle("bundle_dynamic_" .. suffix, faction_key, 0)
+''',
+        encoding='utf-8',
+    )
+    output = tmp_path / 'out.json'
+    tool = Path(__file__).with_name('resolve_script_effect_bundle_sources.py')
+    subprocess.run([
+        sys.executable, str(tool),
+        '--scripts-dir', str(scripts),
+        '--output', str(output),
+        '--game-version', 'fixture',
+    ], check=True)
+    data = json.loads(output.read_text(encoding='utf-8'))
+    pairs = {(x['faction'], x['effectBundle']) for x in data['assignments']}
+    assert ('wh_main_emp_empire', 'bundle_literal') in pairs
+    assert ('wh3_main_ksl_the_ice_court', 'bundle_variable') in pairs
+    assert ('wh2_main_hef_eataine', 'bundle_ambiguous') not in pairs
+    assert ('wh2_main_hef_avelorn', 'bundle_ambiguous') not in pairs
+    assert data['diagnostics']['unresolvedCalls'] == 1


### PR DESCRIPTION
Avance #1 et #5.

- ajoute un resolver conservateur des appels `cm:apply_effect_bundle(...)` dans les scripts de campagne ;
- n'émet une attribution faction -> bundle que si la faction est statiquement démontrable (littéral ou constante unique dans le fichier) ;
- signale les appels dynamiques/ambigus au lieu de deviner ;
- scanne automatiquement `script/campaign` du dump WH3 épinglé dans GitHub Actions ;
- publie `script-effect-bundle-sources.json` avec les autres datasets Pages ;
- ajoute un test automatisé couvrant littéral, constante, ambiguïté et bundle dynamique.

Important : ce dataset prouve qu'un script peut appliquer un bundle à une faction, mais ne prétend pas encore que l'appel s'exécute au tour 1. Cette distinction est conservée dans les métadonnées.