### PR TITLE
feat: générer les candidats de modificateurs diplomatiques tour 1

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -99,6 +99,13 @@ jobs:
             --campaign wh3_main_combi \
             --game-version "${GAME_VERSION}"
 
+          python tools/resolve_turn1_diplomatic_modifier_candidates.py \
+            --script-sources data/generated/script-effect-bundle-sources.json \
+            --effect-values data/generated/diplomatic-effect-values.json \
+            --output data/generated/turn1-diplomatic-modifier-candidates.json \
+            --campaign wh3_main_combi \
+            --game-version "${GAME_VERSION}"
+
           for file in \
             immortal-empires-startpos.json \
             frontend-leaders.json \
@@ -106,7 +113,8 @@ jobs:
             cultural-relations.json \
             diplomatic-effect-targets.json \
             diplomatic-effect-values.json \
-            script-effect-bundle-sources.json; do
+            script-effect-bundle-sources.json \
+            turn1-diplomatic-modifier-candidates.json; do
             cp "data/generated/${file}" "data/runtime/${file}"
           done
 
@@ -129,7 +137,8 @@ jobs:
             data/generated/cultural-relations.json \
             data/generated/diplomatic-effect-targets.json \
             data/generated/diplomatic-effect-values.json \
-            data/generated/script-effect-bundle-sources.json; do
+            data/generated/script-effect-bundle-sources.json \
+            data/generated/turn1-diplomatic-modifier-candidates.json; do
             if ! git ls-files --error-unmatch "$file" >/dev/null 2>&1; then
               git add "$file"
               changed=1

--- a/tools/resolve_turn1_diplomatic_modifier_candidates.py
+++ b/tools/resolve_turn1_diplomatic_modifier_candidates.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Join first-tick script bundle applications with diplomatic effect values.
+
+The result is intentionally a *candidate* dataset. A bundle placed inside a
+campaign first-tick callback can still sit behind a condition that is false for
+some campaigns/factions. Therefore this tool never labels the modifier as a
+verified active turn-1 modifier; it only builds the auditable join:
+
+source faction -> first-tick bundle -> diplomatic effect/value -> target(s)
+"""
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def load(path, label):
+    if not path.is_file():
+        raise SystemExit(f'turn-1 modifier candidate resolver failed: missing {label}: {path}')
+    return json.loads(path.read_text(encoding='utf-8'))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--script-sources', type=Path, required=True)
+    parser.add_argument('--effect-values', type=Path, required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--game-version', required=True)
+    parser.add_argument('--campaign', default='wh3_main_combi')
+    args = parser.parse_args()
+
+    sources = load(args.script_sources, 'script source dataset')
+    values = load(args.effect_values, 'effect value dataset')
+
+    effects_by_bundle = {
+        item['effectBundle']: item.get('diplomaticEffects', [])
+        for item in values.get('effectBundles', [])
+    }
+
+    candidates = []
+    skipped_without_diplomatic_effect = 0
+    for assignment in sources.get('assignments', []):
+        if not assignment.get('firstTickCallback'):
+            continue
+        effects = effects_by_bundle.get(assignment.get('effectBundle'), [])
+        if not effects:
+            skipped_without_diplomatic_effect += 1
+            continue
+        for effect in effects:
+            candidates.append({
+                'sourceFaction': assignment['faction'],
+                'effectBundle': assignment['effectBundle'],
+                'effect': effect['effect'],
+                'value': effect['value'],
+                'scope': effect.get('scope'),
+                'advancementStage': effect.get('advancementStage'),
+                'targets': effect.get('targets', []),
+                'evidence': {
+                    'kind': 'first-tick-script-candidate',
+                    'conditional': True,
+                    'sourceFile': assignment.get('sourceFile'),
+                    'sourceLine': assignment.get('sourceLine'),
+                    'factionResolution': assignment.get('resolution'),
+                    'turnsExpression': assignment.get('turnsExpression'),
+                },
+            })
+
+    candidates.sort(key=lambda x: (
+        x['sourceFaction'], x['effectBundle'], x['effect'], x['value']
+    ))
+
+    output = {
+        'gameVersion': args.game_version,
+        'campaign': args.campaign,
+        'generatedAt': datetime.now(timezone.utc).isoformat(),
+        'status': 'candidate',
+        'semantics': 'first-tick script candidates only; conditional execution is not yet proven, so these values must not be added to the final attitude score without verification',
+        'candidates': candidates,
+        'diagnostics': {
+            'candidateCount': len(candidates),
+            'sourceFactionCount': len({item['sourceFaction'] for item in candidates}),
+            'skippedFirstTickBundlesWithoutDiplomaticEffect': skipped_without_diplomatic_effect,
+        },
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(output, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
+    print(f"resolved {len(candidates)} first-tick diplomatic modifier candidates")
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/test_resolve_turn1_diplomatic_modifier_candidates.py
+++ b/tools/test_resolve_turn1_diplomatic_modifier_candidates.py
@@ -1,0 +1,69 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_turn1_candidate_join(tmp_path):
+    sources = tmp_path / 'sources.json'
+    values = tmp_path / 'values.json'
+    output = tmp_path / 'out.json'
+    sources.write_text(json.dumps({
+        'assignments': [
+            {
+                'faction': 'wh_main_emp_empire',
+                'effectBundle': 'bundle_diplomacy',
+                'firstTickCallback': True,
+                'resolution': 'literal',
+                'turnsExpression': '0',
+                'sourceFile': 'sample.lua',
+                'sourceLine': 12,
+            },
+            {
+                'faction': 'wh2_main_hef_eataine',
+                'effectBundle': 'bundle_later',
+                'firstTickCallback': False,
+            },
+        ]
+    }), encoding='utf-8')
+    values.write_text(json.dumps({
+        'effectBundles': [
+            {
+                'effectBundle': 'bundle_diplomacy',
+                'diplomaticEffects': [
+                    {
+                        'effect': 'effect_relations',
+                        'value': 60.0,
+                        'scope': 'faction_to_faction_own_unseen',
+                        'advancementStage': 'start_round_completed',
+                        'targets': [
+                            {'targetType': 'subculture', 'target': 'wh_main_sc_dwf_dwarfs'}
+                        ],
+                    }
+                ],
+            },
+            {
+                'effectBundle': 'bundle_later',
+                'diplomaticEffects': [{'effect': 'should_not_emit', 'value': -40.0}],
+            },
+        ]
+    }), encoding='utf-8')
+
+    tool = Path(__file__).with_name('resolve_turn1_diplomatic_modifier_candidates.py')
+    subprocess.run([
+        sys.executable, str(tool),
+        '--script-sources', str(sources),
+        '--effect-values', str(values),
+        '--output', str(output),
+        '--game-version', 'fixture',
+    ], check=True)
+
+    data = json.loads(output.read_text(encoding='utf-8'))
+    assert data['status'] == 'candidate'
+    assert data['diagnostics']['candidateCount'] == 1
+    candidate = data['candidates'][0]
+    assert candidate['sourceFaction'] == 'wh_main_emp_empire'
+    assert candidate['value'] == 60.0
+    assert candidate['targets'][0]['target'] == 'wh_main_sc_dwf_dwarfs'
+    assert candidate['evidence']['kind'] == 'first-tick-script-candidate'
+    assert candidate['evidence']['conditional'] is True


### PR DESCRIPTION
Avance #1 et #5.

- ajoute `resolve_turn1_diplomatic_modifier_candidates.py` ;
- joint uniquement les bundles détectés dans un callback premier tick aux effets diplomatiques chiffrés ;
- produit la chaîne auditable `faction source -> bundle -> effet -> valeur -> cibles` ;
- conserve explicitement `status: candidate` et `conditional: true` pour ne pas confondre présence dans un callback premier tick et application réellement active ;
- publie et persiste `turn1-diplomatic-modifier-candidates.json` via GitHub Pages ;
- ajoute un test de jointure avec une valeur +60.

Prochaine étape : vérifier les conditions des candidats puis injecter uniquement les modificateurs prouvés dans le calcul final affiché par la matrice et Accord rapide.