### PR TITLE
feat: produire un sous-ensemble vérifié des modificateurs diplomatiques tour 1

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -108,6 +108,12 @@ jobs:
             --campaign wh3_main_combi \
             --game-version "${GAME_VERSION}"
 
+          python tools/resolve_verified_turn1_diplomatic_modifiers.py \
+            --candidates data/generated/turn1-diplomatic-modifier-candidates.json \
+            --output data/generated/verified-turn1-diplomatic-modifiers.json \
+            --campaign wh3_main_combi \
+            --game-version "${GAME_VERSION}"
+
           for file in \
             immortal-empires-startpos.json \
             frontend-leaders.json \
@@ -116,7 +122,8 @@ jobs:
             diplomatic-effect-targets.json \
             diplomatic-effect-values.json \
             script-effect-bundle-sources.json \
-            turn1-diplomatic-modifier-candidates.json; do
+            turn1-diplomatic-modifier-candidates.json \
+            verified-turn1-diplomatic-modifiers.json; do
             cp "data/generated/${file}" "data/runtime/${file}"
           done
 
@@ -140,7 +147,8 @@ jobs:
             data/generated/diplomatic-effect-targets.json \
             data/generated/diplomatic-effect-values.json \
             data/generated/script-effect-bundle-sources.json \
-            data/generated/turn1-diplomatic-modifier-candidates.json; do
+            data/generated/turn1-diplomatic-modifier-candidates.json \
+            data/generated/verified-turn1-diplomatic-modifiers.json; do
             if ! git ls-files --error-unmatch "$file" >/dev/null 2>&1; then
               git add "$file"
               changed=1

--- a/tools/resolve_script_effect_bundle_sources.py
+++ b/tools/resolve_script_effect_bundle_sources.py
@@ -8,13 +8,14 @@ assignment in the same file. Dynamic concatenations and ambiguous variables are
 reported but never guessed.
 
 Calls lexically contained in a `cm:add_first_tick_callback*()` invocation are
-marked as first-tick execution evidence. This is stronger evidence that the call
-can execute at campaign start, but it still does not prove that every condition
-inside the callback is true for a specific faction/campaign.
+marked as first-tick execution evidence. `guardFreeFirstTick=true` is an even
+more conservative signal: no `if`, `for`, `while` or `repeat` token occurs
+between the start of the enclosing callback and the bundle call. This can miss
+valid unconditional calls (false negatives), but it avoids promoting visibly
+guarded calls as verified turn-1 effects.
 
 `--exclude-prefix` can be repeated to exclude campaign-specific script trees
-that are not part of the requested campaign (for example Realms of Chaos and
-the prologue when resolving Immortal Empires).
+that are not part of the requested campaign.
 """
 import argparse
 import json
@@ -29,6 +30,7 @@ CALL_RE = re.compile(
     re.MULTILINE,
 )
 FIRST_TICK_RE = re.compile(r'cm:add_first_tick_callback[A-Za-z0-9_]*\s*\(')
+CONTROL_FLOW_RE = re.compile(r'\b(?:if\b[^\n]*\bthen\b|for\b[^\n]*\bdo\b|while\b[^\n]*\bdo\b|repeat\b)', re.IGNORECASE)
 FACTION_KEY_RE = re.compile(r'^(?:wh|wh2|wh3)_[a-z0-9_]+$')
 
 
@@ -91,8 +93,18 @@ def first_tick_ranges(text):
     return ranges
 
 
-def in_ranges(index, ranges):
-    return any(start <= index < end for start, end in ranges)
+def enclosing_range(index, ranges):
+    matches = [(start, end) for start, end in ranges if start <= index < end]
+    if not matches:
+        return None
+    return max(matches, key=lambda item: item[0])
+
+
+def guard_free_first_tick(text, call_index, tick_range):
+    if not tick_range:
+        return False
+    prefix = text[tick_range[0]:call_index]
+    return CONTROL_FLOW_RE.search(prefix) is None
 
 
 def scan_file(path, root):
@@ -109,31 +121,32 @@ def scan_file(path, root):
         faction_expr = match.group(3).strip()
         turns_expr = match.group(4).strip()
         faction, resolution = resolve_arg(faction_expr, assignments)
-        first_tick = in_ranges(match.start(), tick_ranges)
+        tick_range = enclosing_range(match.start(), tick_ranges)
+        first_tick = tick_range is not None
+        guard_free = guard_free_first_tick(text, match.start(), tick_range)
         line = text.count('\n', 0, match.start()) + 1
         source = str(path.relative_to(root)).replace('\\', '/')
-        execution_evidence = 'first-tick-callback' if first_tick else 'script-call'
+        execution_evidence = 'guard-free-first-tick' if guard_free else ('first-tick-callback' if first_tick else 'script-call')
+        record = {
+            'effectBundle': bundle,
+            'turnsExpression': turns_expr,
+            'executionEvidence': execution_evidence,
+            'firstTickCallback': first_tick,
+            'guardFreeFirstTick': guard_free,
+            'sourceFile': source,
+            'sourceLine': line,
+        }
         if faction and FACTION_KEY_RE.match(faction):
             resolved.append({
                 'faction': faction,
-                'effectBundle': bundle,
-                'turnsExpression': turns_expr,
                 'resolution': resolution,
-                'executionEvidence': execution_evidence,
-                'firstTickCallback': first_tick,
-                'sourceFile': source,
-                'sourceLine': line,
+                **record,
             })
         else:
             unresolved.append({
-                'effectBundle': bundle,
                 'factionExpression': faction_expr,
-                'turnsExpression': turns_expr,
                 'reason': resolution if faction is None else 'resolved-value-is-not-a-faction-key',
-                'executionEvidence': execution_evidence,
-                'firstTickCallback': first_tick,
-                'sourceFile': source,
-                'sourceLine': line,
+                **record,
             })
     return resolved, unresolved
 
@@ -171,13 +184,14 @@ def main():
         dedup[key] = item
     resolved = sorted(dedup.values(), key=lambda x: (x['faction'], x['effectBundle'], x['sourceFile'], x['sourceLine']))
     first_tick_count = sum(1 for item in resolved if item['firstTickCallback'])
+    guard_free_count = sum(1 for item in resolved if item['guardFreeFirstTick'])
 
     output = {
         'gameVersion': args.game_version,
         'campaign': args.campaign,
         'generatedAt': datetime.now(timezone.utc).isoformat(),
         'status': 'partial',
-        'semantics': 'static script assignments scoped to the requested campaign; firstTickCallback=true proves lexical placement in a campaign first-tick callback, but conditional execution still requires separate verification',
+        'semantics': 'static script assignments scoped to the requested campaign; guardFreeFirstTick is conservative evidence of an unguarded first-tick call, not proof that every external prerequisite is satisfied',
         'assignments': resolved,
         'diagnostics': {
             'luaFilesDiscovered': len(all_files),
@@ -186,13 +200,14 @@ def main():
             'excludedPrefixes': args.exclude_prefix,
             'resolvedAssignments': len(resolved),
             'firstTickAssignments': first_tick_count,
+            'guardFreeFirstTickAssignments': guard_free_count,
             'unresolvedCalls': len(unresolved),
             'unresolved': unresolved,
         },
     }
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(output, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
-    print(f"resolved {len(resolved)} static faction/bundle assignments ({first_tick_count} in first-tick callbacks) from {len(files)} scoped Lua files; excluded {len(excluded_files)}")
+    print(f"resolved {len(resolved)} assignments; {first_tick_count} first-tick, {guard_free_count} guard-free first-tick")
 
 
 if __name__ == '__main__':

--- a/tools/resolve_turn1_diplomatic_modifier_candidates.py
+++ b/tools/resolve_turn1_diplomatic_modifier_candidates.py
@@ -1,13 +1,5 @@
 #!/usr/bin/env python3
-"""Join first-tick script bundle applications with diplomatic effect values.
-
-The result is intentionally a *candidate* dataset. A bundle placed inside a
-campaign first-tick callback can still sit behind a condition that is false for
-some campaigns/factions. Therefore this tool never labels the modifier as a
-verified active turn-1 modifier; it only builds the auditable join:
-
-source faction -> first-tick bundle -> diplomatic effect/value -> target(s)
-"""
+"""Join first-tick script bundle applications with diplomatic effect values."""
 import argparse
 import json
 from datetime import datetime, timezone
@@ -31,11 +23,7 @@ def main():
 
     sources = load(args.script_sources, 'script source dataset')
     values = load(args.effect_values, 'effect value dataset')
-
-    effects_by_bundle = {
-        item['effectBundle']: item.get('diplomaticEffects', [])
-        for item in values.get('effectBundles', [])
-    }
+    effects_by_bundle = {item['effectBundle']: item.get('diplomaticEffects', []) for item in values.get('effectBundles', [])}
 
     candidates = []
     skipped_without_diplomatic_effect = 0
@@ -46,6 +34,7 @@ def main():
         if not effects:
             skipped_without_diplomatic_effect += 1
             continue
+        guard_free = bool(assignment.get('guardFreeFirstTick'))
         for effect in effects:
             candidates.append({
                 'sourceFaction': assignment['faction'],
@@ -56,8 +45,9 @@ def main():
                 'advancementStage': effect.get('advancementStage'),
                 'targets': effect.get('targets', []),
                 'evidence': {
-                    'kind': 'first-tick-script-candidate',
-                    'conditional': True,
+                    'kind': 'guard-free-first-tick' if guard_free else 'first-tick-script-candidate',
+                    'conditional': not guard_free,
+                    'guardFreeFirstTick': guard_free,
                     'sourceFile': assignment.get('sourceFile'),
                     'sourceLine': assignment.get('sourceLine'),
                     'factionResolution': assignment.get('resolution'),
@@ -65,19 +55,17 @@ def main():
                 },
             })
 
-    candidates.sort(key=lambda x: (
-        x['sourceFaction'], x['effectBundle'], x['effect'], x['value']
-    ))
-
+    candidates.sort(key=lambda x: (x['sourceFaction'], x['effectBundle'], x['effect'], x['value']))
     output = {
         'gameVersion': args.game_version,
         'campaign': args.campaign,
         'generatedAt': datetime.now(timezone.utc).isoformat(),
         'status': 'candidate',
-        'semantics': 'first-tick script candidates only; conditional execution is not yet proven, so these values must not be added to the final attitude score without verification',
+        'semantics': 'first-tick script candidates; guardFreeFirstTick=true is conservative evidence that no visible control-flow guard precedes the call inside the callback',
         'candidates': candidates,
         'diagnostics': {
             'candidateCount': len(candidates),
+            'guardFreeCandidateCount': sum(1 for item in candidates if item['evidence']['guardFreeFirstTick']),
             'sourceFactionCount': len({item['sourceFaction'] for item in candidates}),
             'skippedFirstTickBundlesWithoutDiplomaticEffect': skipped_without_diplomatic_effect,
         },

--- a/tools/resolve_verified_turn1_diplomatic_modifiers.py
+++ b/tools/resolve_verified_turn1_diplomatic_modifiers.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Promote only guard-free first-tick diplomatic candidates to verified data.
+
+This verifier is deliberately conservative. It accepts a candidate only when:
+- it comes from a statically resolved faction -> bundle assignment;
+- the bundle call is inside a first-tick callback;
+- no visible `if`, `for`, `while` or `repeat` guard precedes the call inside
+  that callback (`guardFreeFirstTick=true`).
+
+This is sufficient to remove obvious conditionally executed candidates. It does
+not attempt to prove hidden engine prerequisites or semantics outside the Lua
+source, so provenance is retained for every promoted modifier.
+"""
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def load(path):
+    if not path.is_file():
+        raise SystemExit(f'verified turn-1 modifier resolver failed: missing input {path}')
+    return json.loads(path.read_text(encoding='utf-8'))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--candidates', type=Path, required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--game-version', required=True)
+    parser.add_argument('--campaign', default='wh3_main_combi')
+    args = parser.parse_args()
+
+    data = load(args.candidates)
+    verified = []
+    rejected = []
+    for item in data.get('candidates', []):
+        evidence = item.get('evidence') or {}
+        if evidence.get('guardFreeFirstTick') is True and evidence.get('conditional') is False:
+            promoted = dict(item)
+            promoted['status'] = 'verified-guard-free-first-tick'
+            verified.append(promoted)
+        else:
+            rejected.append({
+                'sourceFaction': item.get('sourceFaction'),
+                'effectBundle': item.get('effectBundle'),
+                'effect': item.get('effect'),
+                'reason': 'conditional-or-not-guard-free',
+                'sourceFile': evidence.get('sourceFile'),
+                'sourceLine': evidence.get('sourceLine'),
+            })
+
+    verified.sort(key=lambda x: (x['sourceFaction'], x['effectBundle'], x['effect'], x['value']))
+    output = {
+        'gameVersion': args.game_version,
+        'campaign': args.campaign,
+        'generatedAt': datetime.now(timezone.utc).isoformat(),
+        'status': 'verified-subset',
+        'semantics': 'conservative subset of first-tick diplomatic modifiers with statically resolved faction and no visible control-flow guard before the bundle call inside its first-tick callback',
+        'modifiers': verified,
+        'diagnostics': {
+            'verifiedModifierCount': len(verified),
+            'verifiedSourceFactionCount': len({item['sourceFaction'] for item in verified}),
+            'rejectedCandidateCount': len(rejected),
+            'rejected': rejected,
+        },
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(output, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
+    print(f"promoted {len(verified)} guard-free first-tick diplomatic modifiers")
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/test_resolve_script_effect_bundle_sources.py
+++ b/tools/test_resolve_script_effect_bundle_sources.py
@@ -39,10 +39,13 @@ cm:apply_effect_bundle("bundle_dynamic_" .. suffix, faction_key, 0)
     assert by_bundle['bundle_literal']['firstTickCallback'] is False
     assert by_bundle['bundle_first_tick']['faction'] == 'wh3_main_ksl_the_ice_court'
     assert by_bundle['bundle_first_tick']['firstTickCallback'] is True
-    assert by_bundle['bundle_first_tick']['executionEvidence'] == 'first-tick-callback'
+    assert by_bundle['bundle_first_tick']['guardFreeFirstTick'] is True
+    assert by_bundle['bundle_first_tick']['executionEvidence'] == 'guard-free-first-tick'
     assert by_bundle['bundle_nested_first_tick']['firstTickCallback'] is True
+    assert by_bundle['bundle_nested_first_tick']['guardFreeFirstTick'] is False
     pairs = {(x['faction'], x['effectBundle']) for x in data['assignments']}
     assert ('wh2_main_hef_eataine', 'bundle_ambiguous') not in pairs
     assert ('wh2_main_hef_avelorn', 'bundle_ambiguous') not in pairs
     assert data['diagnostics']['firstTickAssignments'] == 2
+    assert data['diagnostics']['guardFreeFirstTickAssignments'] == 1
     assert data['diagnostics']['unresolvedCalls'] == 1

--- a/tools/test_resolve_verified_turn1_diplomatic_modifiers.py
+++ b/tools/test_resolve_verified_turn1_diplomatic_modifiers.py
@@ -1,0 +1,45 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_verified_turn1_modifier_promotion(tmp_path):
+    candidates = {
+        'candidates': [
+            {
+                'sourceFaction': 'wh2_dlc11_cst_vampire_coast',
+                'effectBundle': 'bundle_verified',
+                'effect': 'effect_followers_of_nagash',
+                'value': 60.0,
+                'scope': 'faction_to_faction_own_unseen',
+                'targets': [{'targetType': 'faction', 'target': 'wh2_dlc09_tmb_followers_of_nagash'}],
+                'evidence': {'guardFreeFirstTick': True, 'conditional': False, 'sourceFile': 'sample.lua', 'sourceLine': 10},
+            },
+            {
+                'sourceFaction': 'wh2_dlc11_cst_vampire_coast',
+                'effectBundle': 'bundle_guarded',
+                'effect': 'effect_lizardmen',
+                'value': -60.0,
+                'scope': 'faction_to_faction_own_unseen',
+                'targets': [{'targetType': 'subculture', 'target': 'wh2_main_sc_lzd_lizardmen'}],
+                'evidence': {'guardFreeFirstTick': False, 'conditional': True, 'sourceFile': 'sample.lua', 'sourceLine': 20},
+            },
+        ]
+    }
+    source = tmp_path / 'candidates.json'
+    output = tmp_path / 'verified.json'
+    source.write_text(json.dumps(candidates), encoding='utf-8')
+    tool = Path(__file__).with_name('resolve_verified_turn1_diplomatic_modifiers.py')
+    subprocess.run([
+        sys.executable, str(tool),
+        '--candidates', str(source),
+        '--output', str(output),
+        '--game-version', 'fixture',
+    ], check=True)
+    data = json.loads(output.read_text(encoding='utf-8'))
+    assert data['diagnostics']['verifiedModifierCount'] == 1
+    assert data['diagnostics']['rejectedCandidateCount'] == 1
+    assert data['modifiers'][0]['effectBundle'] == 'bundle_verified'
+    assert data['modifiers'][0]['value'] == 60.0
+    assert data['modifiers'][0]['status'] == 'verified-guard-free-first-tick'


### PR DESCRIPTION
Avance #1 et #5.

- ajoute `guardFreeFirstTick` au resolver des scripts : un appel premier tick n'est promu que si aucun `if`, `for`, `while` ou `repeat` visible ne le précède dans le callback ;
- propage cette preuve dans les candidats diplomatiques ;
- ajoute `resolve_verified_turn1_diplomatic_modifiers.py` qui produit uniquement le sous-ensemble conservateur `verified-turn1-diplomatic-modifiers.json` ;
- conserve la provenance fichier/ligne et rejette explicitement les candidats conditionnels ;
- publie/persiste ce nouveau dataset via GitHub Pages ;
- ajoute des tests pour les appels premier tick gardés/non gardés et la promotion d'une valeur diplomatique +60.

Le filtre est volontairement conservateur : il peut rater des effets valides, mais il ne transforme pas un effet derrière une condition visible en valeur certaine.